### PR TITLE
Fork helm-operator adjustments for CI and documentation

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,5 @@
+upstream-triage:
+  - "./*"
 area/main-binary:
   - 'main.go'
   - 'internal/**/*'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,7 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - '**'
-  pull_request:
-    branches: [ main ]
+  - push
 
 jobs:
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,13 +1,14 @@
 name: Deploy
 
-on:
-  push:
-    branches:
-      - '**'
-    tags:
-      - 'v*'
-  pull_request:
-    branches: [ main ]
+# Disabled as we don't need docker images to use the helm-operator as a library.
+#on:
+#  push:
+#    branches:
+#      - '**'
+#    tags:
+#      - 'v*'
+#  pull_request:
+#    branches: [ main ]
 
 jobs:
   goreleaser:

--- a/README.md
+++ b/README.md
@@ -4,21 +4,26 @@
 
 Experimental refactoring of the operator-framework's helm operator
 
-### Why a fork?
+## Why a fork?
 
-As the helm-operator is an experimental refactoring and not actively maintained we started a fork to 
-further support [hybrid operators](https://github.com/operator-framework/operator-sdk/issues/670) based on Helm.
+Initially the Helm operator type was designed to automate Helm chart operations
+by mapping the [values](https://helm.sh/docs/chart_template_guide/values_files/) of a Helm chart exactly to a 
+`CustomResourceDefinition` and defining its watched resources in a `watches.yaml` 
+[configuration](https://sdk.operatorframework.io/docs/building-operators/helm/tutorial/#watch-the-nginx-cr).
 
-This fork should used as a library and not is recommended to watch CustomResources by configured `watches`.
+To write a [Level II+](https://sdk.operatorframework.io/docs/advanced-topics/operator-capabilities/operator-capabilities/) operator 
+which reuses an already existing Helm chart a [hybrid](https://github.com/operator-framework/operator-sdk/issues/670)
+between the Go and Helm operator type is necessary.
 
-### Quickstart
+The hybrid approach allows to add customizations to the Helm operator like value mapping based on cluster state or
+executing code in on specific events.
 
-Add this lib as a replace directive to your `go.mod`:
+## Quickstart
+
+Add this module as a replace directive to your `go.mod`:
 
 ```
-replace(
-    github.com/joelanford/helm-operator => github.com/stackrox/helm-operator
-)
+go mod edit -replace=github.com/joelanford/helm-operator=github.com/stackrox/helm-operator@main
 ```
 
 Example:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,41 @@
 # helm-operator
 
-[![Build Status](https://github.com/joelanford/helm-operator/workflows/CI/badge.svg?branch=master)
-[![Coverage Status](https://coveralls.io/repos/github/joelanford/helm-operator/badge.svg?branch=master)](https://coveralls.io/github/joelanford/helm-operator?branch=master)
+[![Build Status](https://github.com/stackrox/helm-operator/workflows/CI/badge.svg?branch=main)
 
 Experimental refactoring of the operator-framework's helm operator
+
+### Why a fork?
+
+As the helm-operator is an experimental refactoring and not actively maintained we started a fork to 
+further support [hybrid operators](https://github.com/operator-framework/operator-sdk/issues/670) based on Helm.
+
+This fork should used as a library and not is recommended to watch CustomResources by configured `watches`.
+
+### Quickstart
+
+Add this lib as a replace directive to your `go.mod`:
+
+```
+replace(
+    github.com/joelanford/helm-operator => github.com/stackrox/helm-operator
+)
+```
+
+Example:
+
+```
+chart, err := loader.Load("path/to/chart")
+if err != nil {
+    panic(err)
+}
+
+reconciler := reconciler.New(
+    reconciler.WithChart(*chart),
+    reconciler.WithGroupVersionKind(gvk),
+)
+
+if err := reconciler.SetupWithManager(mgr); err != nil {
+    panic(fmt.Sprintf("unable to create reconciler: %s", err))
+}
+```
+


### PR DESCRIPTION
CI migration of the helm-operator fork. 
Did not deleted the original deploy actions.

 - Disable some docker image push
 - Execute CI on all pushes
