### PR TITLE
Pass context to Translate().

### DIFF
--- a/pkg/reconciler/internal/values/values.go
+++ b/pkg/reconciler/internal/values/values.go
@@ -17,6 +17,7 @@ limitations under the License.
 package values
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -69,7 +70,7 @@ func (v *Values) ApplyOverrides(in map[string]string) error {
 
 var DefaultMapper = values.MapperFunc(func(v chartutil.Values) chartutil.Values { return v })
 
-var DefaultTranslator = values.TranslatorFunc(func(u *unstructured.Unstructured) (chartutil.Values, error) {
+var DefaultTranslator = values.TranslatorFunc(func(ctx context.Context, u *unstructured.Unstructured) (chartutil.Values, error) {
 	internalValues, err := FromUnstructured(u)
 	if err != nil {
 		return chartutil.Values{}, err

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -471,7 +471,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.
 		return ctrl.Result{}, err
 	}
 
-	vals, err := r.getValues(obj)
+	vals, err := r.getValues(ctx, obj)
 	if err != nil {
 		u.UpdateStatus(
 			updater.EnsureCondition(conditions.Irreconcilable(corev1.ConditionTrue, conditions.ReasonErrorGettingValues, err)),
@@ -534,8 +534,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.
 	return ctrl.Result{RequeueAfter: r.reconcilePeriod}, nil
 }
 
-func (r *Reconciler) getValues(obj *unstructured.Unstructured) (chartutil.Values, error) {
-	vals, err := r.valueTranslator.Translate(obj)
+func (r *Reconciler) getValues(ctx context.Context, obj *unstructured.Unstructured) (chartutil.Values, error) {
+	vals, err := r.valueTranslator.Translate(ctx, obj)
 	if err != nil {
 		return chartutil.Values{}, err
 	}

--- a/pkg/values/values.go
+++ b/pkg/values/values.go
@@ -17,6 +17,7 @@ limitations under the License.
 package values
 
 import (
+	"context"
 	"helm.sh/helm/v3/pkg/chartutil"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -34,11 +35,11 @@ func (m MapperFunc) Map(v chartutil.Values) chartutil.Values {
 }
 
 type Translator interface {
-	Translate(unstructured *unstructured.Unstructured) (chartutil.Values, error)
+	Translate(ctx context.Context, unstructured *unstructured.Unstructured) (chartutil.Values, error)
 }
 
-type TranslatorFunc func(*unstructured.Unstructured) (chartutil.Values, error)
+type TranslatorFunc func(context.Context, *unstructured.Unstructured) (chartutil.Values, error)
 
-func (t TranslatorFunc) Translate(u *unstructured.Unstructured) (chartutil.Values, error) {
-	return t(u)
+func (t TranslatorFunc) Translate(ctx context.Context, u *unstructured.Unstructured) (chartutil.Values, error) {
+	return t(ctx, u)
 }


### PR DESCRIPTION
This is necessary for proper deadline propagation in case `Translate` talks to the network.