### PR TITLE
Disable scheme registration in SetupWithManager

### DIFF
--- a/internal/cmd/run/cmd.go
+++ b/internal/cmd/run/cmd.go
@@ -169,7 +169,7 @@ func (r *run) run(cmd *cobra.Command) {
 			os.Exit(1)
 		}
 
-		if err := r.SetupWithManager(mgr); err != nil {
+		if err := r.SetupWithManager(mgr, reconciler.SetupOpts{}); err != nil {
 			log.Error(err, "unable to create controller", "controller", "Helm")
 			os.Exit(1)
 		}

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -116,6 +116,10 @@ func (r *Reconciler) setupAnnotationMaps() {
 	r.uninstallAnnotations = make(map[string]annotation.Uninstall)
 }
 
+type SetupOpts struct {
+	DisableSetupScheme bool
+}
+
 // SetupWithManager configures a controller for the Reconciler and registers
 // watches. It also uses the passed Manager to initialize default values for the
 // Reconciler and sets up the manager's scheme with the Reconciler's configured
@@ -123,11 +127,13 @@ func (r *Reconciler) setupAnnotationMaps() {
 //
 // If an error occurs setting up the Reconciler with the manager, it is
 // returned.
-func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, opts SetupOpts) error {
 	controllerName := fmt.Sprintf("%v-controller", strings.ToLower(r.gvk.Kind))
 
 	r.addDefaults(mgr, controllerName)
-	r.setupScheme(mgr)
+	if !opts.DisableSetupScheme {
+		r.setupScheme(mgr)
+	}
 
 	c, err := controller.New(controllerName, mgr, controller.Options{Reconciler: r, MaxConcurrentReconciles: r.maxConcurrentReconciles})
 	if err != nil {

--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -397,7 +397,7 @@ var _ = Describe("Reconciler", func() {
 				}),
 			)
 			Expect(err).To(BeNil())
-			Expect(r.SetupWithManager(mgr)).To(Succeed())
+			Expect(r.SetupWithManager(mgr, SetupOpts{})).To(Succeed())
 
 			ac, err = r.actionClientGetter.ActionClientFor(obj)
 			Expect(err).To(BeNil())


### PR DESCRIPTION
This change introduces an option to disable registration of unknown types in the kube client.
We register these types in the `main.go:init()` func and inside our test suite.
