### PR TITLE
[WIP] ROX-7352 unlock pending helm actions

### DIFF
--- a/pkg/client/actionclient.go
+++ b/pkg/client/actionclient.go
@@ -183,7 +183,7 @@ func (c *actionClient) Upgrade(name, namespace string, chrt *chart.Chart, vals m
 
 func (c *actionClient) Rollback(name string, opts ...RollbackOption) error {
 	rollback := action.NewRollback(c.conf)
-	for _, o  := range opts {
+	for _, o := range opts {
 		if err := o(rollback); err != nil {
 			return err
 		}

--- a/pkg/reconciler/internal/conditions/conditions.go
+++ b/pkg/reconciler/internal/conditions/conditions.go
@@ -28,7 +28,9 @@ const (
 	TypeInitialized    = "Initialized"
 	TypeDeployed       = "Deployed"
 	TypeReleaseFailed  = "ReleaseFailed"
+	TypeRollbackFailed = "TypeRollbackFailed"
 	TypeIrreconcilable = "Irreconcilable"
+	TypeReleasePending = "ReleasePending"
 
 	ReasonInstallSuccessful   = status.ConditionReason("InstallSuccessful")
 	ReasonUpgradeSuccessful   = status.ConditionReason("UpgradeSuccessful")
@@ -41,6 +43,7 @@ const (
 	ReasonUpgradeError             = status.ConditionReason("UpgradeError")
 	ReasonReconcileError           = status.ConditionReason("ReconcileError")
 	ReasonUninstallError           = status.ConditionReason("UninstallError")
+	ReasonReleasePending           = status.ConditionReason("ReleasePending")
 )
 
 func Initialized(stat corev1.ConditionStatus, reason status.ConditionReason, message interface{}) status.Condition {
@@ -53,6 +56,14 @@ func Deployed(stat corev1.ConditionStatus, reason status.ConditionReason, messag
 
 func ReleaseFailed(stat corev1.ConditionStatus, reason status.ConditionReason, message interface{}) status.Condition {
 	return newCondition(TypeReleaseFailed, stat, reason, message)
+}
+
+func ReleasePending(stat corev1.ConditionStatus, reason status.ConditionReason, message interface{}) status.Condition {
+	return newCondition(TypeReleasePending, stat, reason, message)
+}
+
+func RollbackFailed(stat corev1.ConditionStatus, reason status.ConditionReason, message interface{}) status.Condition {
+	return newCondition(TypeRollbackFailed, stat, reason, message)
 }
 
 func Irreconcilable(stat corev1.ConditionStatus, reason status.ConditionReason, message interface{}) status.Condition {

--- a/pkg/reconciler/internal/fake/actionclient.go
+++ b/pkg/reconciler/internal/fake/actionclient.go
@@ -53,12 +53,14 @@ type ActionClient struct {
 	Upgrades   []UpgradeCall
 	Uninstalls []UninstallCall
 	Reconciles []ReconcileCall
+	Rollbacks  []RollbackCall
 
 	HandleGet       func() (*release.Release, error)
 	HandleInstall   func() (*release.Release, error)
 	HandleUpgrade   func() (*release.Release, error)
 	HandleUninstall func() (*release.UninstallReleaseResponse, error)
 	HandleReconcile func() error
+	HandleRollback  func() error
 }
 
 func NewActionClient() ActionClient {
@@ -118,6 +120,11 @@ type ReconcileCall struct {
 	Release *release.Release
 }
 
+type RollbackCall struct {
+	Name string
+	Opts []client.RollbackOption
+}
+
 func (c *ActionClient) Get(name string, opts ...client.GetOption) (*release.Release, error) {
 	c.Gets = append(c.Gets, GetCall{name, opts})
 	return c.HandleGet()
@@ -141,4 +148,9 @@ func (c *ActionClient) Uninstall(name string, opts ...client.UninstallOption) (*
 func (c *ActionClient) Reconcile(rel *release.Release) error {
 	c.Reconciles = append(c.Reconciles, ReconcileCall{rel})
 	return c.HandleReconcile()
+}
+
+func (c *ActionClient) Rollback(name string, opts ...client.RollbackOption) error {
+	c.Rollbacks = append(c.Rollbacks, RollbackCall{name, opts})
+	return c.HandleRollback()
 }

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -58,7 +58,7 @@ import (
 )
 
 const (
-	uninstallFinalizer    = "uninstall-helm-release"
+	uninstallFinalizer = "uninstall-helm-release"
 	// pendingReleaseTimeout defines the time frame after which a rollback is performed on a given release
 	pendingReleaseTimeout = time.Second * 30
 	// pendingRetryInterval defines the time waiting until the current reconciliation finished to avoid spamming helm actions
@@ -581,6 +581,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.
 		}
 
 	case stateNeedsSkip:
+		// TODO(do-not-merge): set status custom resource status
 		return ctrl.Result{Requeue: true, RequeueAfter: pendingRetryInterval}, nil
 
 	default:


### PR DESCRIPTION
Currently if a Helm install/upgrade/rollback action is interrupted the Helm release status is `*-pending` and thus does not allow Helm to perform any upgrades in the future.

When does a `*-pending` state occur:
- A user executes a helm action
- Another operator executes a helm action
  - unlikely as an operator should only have one instance with leader-election enabled
- Operator exited unexpectedly while performing a helm action
- User interrupted a helm action

To avoid this behaviour this PR introduces a check on `*-pending` Helm release state. If such state is found we assume that an action is currently in progress and set `stateNeedsSkip`.
The operator checks the `LAST_DEPLOYED` timestamp to check against  a timeout of `30 seconds`. As long as the `LAST_DEPLOYED < 30sec ago` the reconciliation is requeued after 5 seconds.
After the timeout is reached a `statedNeedsRollback` is set and a rollback is performed to get rid of the `*-pending` state.


**Testing:**

 - [ ] Test installation is interrupted
 - [ ] Test upgrade is interrupted
 - [ ] Test rollback is interrupted
 - [ ] Automated tests