### PR TITLE
Add EventRecorder to translator

### DIFF
--- a/pkg/reconciler/internal/values/values.go
+++ b/pkg/reconciler/internal/values/values.go
@@ -70,7 +70,7 @@ func (v *Values) ApplyOverrides(in map[string]string) error {
 
 var DefaultMapper = values.MapperFunc(func(v chartutil.Values) chartutil.Values { return v })
 
-var DefaultTranslator = values.TranslatorFunc(func(ctx context.Context, u *unstructured.Unstructured) (chartutil.Values, error) {
+var DefaultTranslator = values.TranslatorFunc(func(ctx context.Context, args values.TranslatorArgs, u *unstructured.Unstructured) (chartutil.Values, error) {
 	internalValues, err := FromUnstructured(u)
 	if err != nil {
 		return chartutil.Values{}, err

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -608,7 +608,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.
 }
 
 func (r *Reconciler) getValues(ctx context.Context, obj *unstructured.Unstructured) (chartutil.Values, error) {
-	vals, err := r.valueTranslator.Translate(ctx, obj)
+	vals, err := r.valueTranslator.Translate(ctx, values.TranslatorArgs{EventRecoder: r.eventRecorder}, obj)
 	if err != nil {
 		return chartutil.Values{}, err
 	}

--- a/pkg/values/values.go
+++ b/pkg/values/values.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"helm.sh/helm/v3/pkg/chartutil"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/tools/record"
 )
 
 // TODO: Consider deprecating Mapper and overrides in favour of Translator.
@@ -34,12 +35,16 @@ func (m MapperFunc) Map(v chartutil.Values) chartutil.Values {
 	return m(v)
 }
 
-type Translator interface {
-	Translate(ctx context.Context, unstructured *unstructured.Unstructured) (chartutil.Values, error)
+type TranslatorArgs struct {
+	EventRecoder record.EventRecorder
 }
 
-type TranslatorFunc func(context.Context, *unstructured.Unstructured) (chartutil.Values, error)
+type Translator interface {
+	Translate(ctx context.Context, args TranslatorArgs, unstructured *unstructured.Unstructured) (chartutil.Values, error)
+}
 
-func (t TranslatorFunc) Translate(ctx context.Context, u *unstructured.Unstructured) (chartutil.Values, error) {
-	return t(ctx, u)
+type TranslatorFunc func(context.Context, TranslatorArgs, *unstructured.Unstructured) (chartutil.Values, error)
+
+func (t TranslatorFunc) Translate(ctx context.Context, args TranslatorArgs, u *unstructured.Unstructured) (chartutil.Values, error) {
+	return t(ctx, args, u)
 }


### PR DESCRIPTION
To emit events during translation an `EventRecorder` is necessary. Passing it as an argument to always have the one used by the Reconciler.
Added `TranslatorArgs` to better avoid breaking changes and adding more arguments if necessary.