### PR TITLE
Allow marking releases stuck in a pending state as failed

### DIFF
--- a/pkg/client/actionclient.go
+++ b/pkg/client/actionclient.go
@@ -189,7 +189,6 @@ func (c *actionClient) Rollback(name string, opts ...RollbackOption) error {
 			return err
 		}
 	}
-	rollback.Force = true
 	return rollback.Run(name)
 }
 

--- a/pkg/client/actionclient.go
+++ b/pkg/client/actionclient.go
@@ -62,7 +62,7 @@ type ActionInterface interface {
 	Get(name string, opts ...GetOption) (*release.Release, error)
 	Install(name, namespace string, chrt *chart.Chart, vals map[string]interface{}, opts ...InstallOption) (*release.Release, error)
 	Upgrade(name, namespace string, chrt *chart.Chart, vals map[string]interface{}, opts ...UpgradeOption) (*release.Release, error)
-	Rollback(name string, opts ...RollbackOption) error
+	MarkFailed(release *release.Release, reason string) error
 	Uninstall(name string, opts ...UninstallOption) (*release.UninstallReleaseResponse, error)
 	Reconcile(rel *release.Release) error
 }
@@ -190,6 +190,14 @@ func (c *actionClient) Rollback(name string, opts ...RollbackOption) error {
 		}
 	}
 	return rollback.Run(name)
+}
+
+func (c *actionClient) MarkFailed(rel *release.Release, reason string) error {
+	infoCopy := *rel.Info
+	releaseCopy := *rel
+	releaseCopy.Info = &infoCopy
+	releaseCopy.SetStatus(release.StatusFailed, reason)
+	return c.conf.Releases.Update(&releaseCopy)
 }
 
 func (c *actionClient) Uninstall(name string, opts ...UninstallOption) (*release.UninstallReleaseResponse, error) {

--- a/pkg/client/actionclient.go
+++ b/pkg/client/actionclient.go
@@ -70,7 +70,6 @@ type ActionInterface interface {
 type GetOption func(*action.Get) error
 type InstallOption func(*action.Install) error
 type UpgradeOption func(*action.Upgrade) error
-type RollbackOption func(*action.Rollback) error
 type UninstallOption func(*action.Uninstall) error
 
 func NewActionClientGetter(acg ActionConfigGetter) ActionClientGetter {
@@ -180,16 +179,6 @@ func (c *actionClient) Upgrade(name, namespace string, chrt *chart.Chart, vals m
 		return nil, err
 	}
 	return rel, nil
-}
-
-func (c *actionClient) Rollback(name string, opts ...RollbackOption) error {
-	rollback := action.NewRollback(c.conf)
-	for _, o := range opts {
-		if err := o(rollback); err != nil {
-			return err
-		}
-	}
-	return rollback.Run(name)
 }
 
 func (c *actionClient) MarkFailed(rel *release.Release, reason string) error {

--- a/pkg/reconciler/internal/conditions/conditions.go
+++ b/pkg/reconciler/internal/conditions/conditions.go
@@ -41,6 +41,7 @@ const (
 	ReasonUpgradeError             = status.ConditionReason("UpgradeError")
 	ReasonReconcileError           = status.ConditionReason("ReconcileError")
 	ReasonUninstallError           = status.ConditionReason("UninstallError")
+	ReasonPendingError             = status.ConditionReason("PendingError")
 )
 
 func Initialized(stat corev1.ConditionStatus, reason status.ConditionReason, message interface{}) status.Condition {

--- a/pkg/reconciler/internal/fake/actionclient.go
+++ b/pkg/reconciler/internal/fake/actionclient.go
@@ -48,19 +48,19 @@ func (hcg *fakeActionClientGetter) ActionClientFor(_ crclient.Object) (client.Ac
 }
 
 type ActionClient struct {
-	Gets       []GetCall
-	Installs   []InstallCall
-	Upgrades   []UpgradeCall
-	Rollbacks  []RollbackCall
-	Uninstalls []UninstallCall
-	Reconciles []ReconcileCall
+	Gets        []GetCall
+	Installs    []InstallCall
+	Upgrades    []UpgradeCall
+	MarkFaileds []MarkFailedCall
+	Uninstalls  []UninstallCall
+	Reconciles  []ReconcileCall
 
-	HandleGet       func() (*release.Release, error)
-	HandleInstall   func() (*release.Release, error)
-	HandleUpgrade   func() (*release.Release, error)
-	HandleRollback  func() error
-	HandleUninstall func() (*release.UninstallReleaseResponse, error)
-	HandleReconcile func() error
+	HandleGet        func() (*release.Release, error)
+	HandleInstall    func() (*release.Release, error)
+	HandleUpgrade    func() (*release.Release, error)
+	HandleMarkFailed func() error
+	HandleUninstall  func() (*release.UninstallReleaseResponse, error)
+	HandleReconcile  func() error
 }
 
 func NewActionClient() ActionClient {
@@ -111,9 +111,9 @@ type UpgradeCall struct {
 	Opts      []client.UpgradeOption
 }
 
-type RollbackCall struct {
-	Name string
-	Opts []client.RollbackOption
+type MarkFailedCall struct {
+	Release *release.Release
+	Reason  string
 }
 
 type UninstallCall struct {
@@ -140,9 +140,9 @@ func (c *ActionClient) Upgrade(name, namespace string, chrt *chart.Chart, vals m
 	return c.HandleUpgrade()
 }
 
-func (c *ActionClient) Rollback(name string, opts ...client.RollbackOption) error {
-	c.Rollbacks = append(c.Rollbacks, RollbackCall{name, opts})
-	return c.HandleRollback()
+func (c *ActionClient) MarkFailed(rel *release.Release, reason string) error {
+	c.MarkFaileds = append(c.MarkFaileds, MarkFailedCall{rel, reason})
+	return c.HandleMarkFailed()
 }
 
 func (c *ActionClient) Uninstall(name string, opts ...client.UninstallOption) (*release.UninstallReleaseResponse, error) {

--- a/pkg/reconciler/internal/fake/actionclient.go
+++ b/pkg/reconciler/internal/fake/actionclient.go
@@ -51,12 +51,14 @@ type ActionClient struct {
 	Gets       []GetCall
 	Installs   []InstallCall
 	Upgrades   []UpgradeCall
+	Rollbacks  []RollbackCall
 	Uninstalls []UninstallCall
 	Reconciles []ReconcileCall
 
 	HandleGet       func() (*release.Release, error)
 	HandleInstall   func() (*release.Release, error)
 	HandleUpgrade   func() (*release.Release, error)
+	HandleRollback  func() error
 	HandleUninstall func() (*release.UninstallReleaseResponse, error)
 	HandleReconcile func() error
 }
@@ -109,6 +111,11 @@ type UpgradeCall struct {
 	Opts      []client.UpgradeOption
 }
 
+type RollbackCall struct {
+	Name string
+	Opts []client.RollbackOption
+}
+
 type UninstallCall struct {
 	Name string
 	Opts []client.UninstallOption
@@ -131,6 +138,11 @@ func (c *ActionClient) Install(name, namespace string, chrt *chart.Chart, vals m
 func (c *ActionClient) Upgrade(name, namespace string, chrt *chart.Chart, vals map[string]interface{}, opts ...client.UpgradeOption) (*release.Release, error) {
 	c.Upgrades = append(c.Upgrades, UpgradeCall{name, namespace, chrt, vals, opts})
 	return c.HandleUpgrade()
+}
+
+func (c *ActionClient) Rollback(name string, opts ...client.RollbackOption) error {
+	c.Rollbacks = append(c.Rollbacks, RollbackCall{name, opts})
+	return c.HandleRollback()
 }
 
 func (c *ActionClient) Uninstall(name string, opts ...client.UninstallOption) (*release.UninstallReleaseResponse, error) {

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -697,7 +697,7 @@ func (r *Reconciler) getReleaseState(client helmclient.ActionInterface, obj meta
 	}
 
 	if currentRelease.Info != nil && currentRelease.Info.Status.IsPending() {
-		return nil, statePending, nil
+		return currentRelease, statePending, nil
 	}
 
 	var opts []helmclient.UpgradeOption

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -803,7 +803,7 @@ func (r *Reconciler) doHandlePending(actionClient helmclient.ActionInterface, re
 	if err != nil {
 		return fmt.Errorf("Failed to mark pending (locked) release as failed: %w", err)
 	}
-	return nil
+	return fmt.Errorf("marked release %s as failed to allow upgrade to succeed in next reconcile attempt", rel.Name)
 }
 
 func (r *Reconciler) reportOverrideEvents(obj runtime.Object) {

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -525,7 +525,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.
 	// We also make sure not to return any errors we encounter so
 	// we can still attempt an uninstall if the CR is being deleted.
 	rel, err := actionClient.Get(obj.GetName())
-	if errors.Is(err, driver.ErrReleaseNotFound) || (rel != nil && rel.Info != nil && rel.Info.Status == release.StatusUninstalled) {
+	if errors.Is(err, driver.ErrReleaseNotFound) {
 		u.UpdateStatus(updater.EnsureCondition(conditions.Deployed(corev1.ConditionFalse, "", "")))
 	} else if err == nil {
 		ensureDeployedRelease(&u, rel)
@@ -692,7 +692,7 @@ func (r *Reconciler) getReleaseState(client helmclient.ActionInterface, obj meta
 		return nil, stateError, err
 	}
 
-	if errors.Is(err, driver.ErrReleaseNotFound) || (currentRelease != nil && currentRelease.Info != nil && currentRelease.Info.Status == release.StatusUninstalled) {
+	if errors.Is(err, driver.ErrReleaseNotFound) {
 		return nil, stateNeedsInstall, nil
 	}
 

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -801,12 +801,14 @@ func (r *Reconciler) doHandlePending(actionClient helmclient.ActionInterface, re
 	var fixAction string
 	var fixErr error
 	if rel.Info.Status == release.StatusPendingInstall {
+		log.Info("Attempting uninstall for locked release", "releaseName", rel.Name)
 		fixAction = "uninstall"
 		_, fixErr = actionClient.Uninstall(rel.Name, func(u *action.Uninstall) error {
 			u.KeepHistory = true
 			return nil
 		})
 	} else {
+		log.Info("Attempting rollback for locked release", "releaseName", rel.Name)
 		fixAction = "rollback"
 		fixErr = actionClient.Rollback(rel.Name, func(r *action.Rollback) error {
 			r.Force = true


### PR DESCRIPTION
This PR adds an option `WithMarkFailedAfter(duration)` which allows marking a release seemingly stuck in a pending state (`pending-install`, `pending-upgrade`, `pending-rollback`) as "failed" after a given timeout (measured from the "last deployed" timestamp). The "failed" state will allow the next "upgrade" operation to succeed.