### PR TITLE
Allow stripping manifest from the CR status

### DIFF
--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -81,6 +81,8 @@ type Reconciler struct {
 	markFailedAfter         time.Duration
 	maxHistory              int
 
+	stripManifestFromStatus bool
+
 	annotSetupOnce       sync.Once
 	annotations          map[string]struct{}
 	installAnnotations   map[string]annotation.Install
@@ -261,6 +263,17 @@ func WithOverrideValues(overrides map[string]string) Option {
 func SkipDependentWatches(skip bool) Option {
 	return func(r *Reconciler) error {
 		r.skipDependentWatches = skip
+		return nil
+	}
+}
+
+// StripManifestFromStatus is an Option that configures whether the manifest
+// should be removed from the automatically populated status.
+// This is recommended if the manifest might return sensitive data (i.e.,
+// secrets).
+func StripManifestFromStatus(strip bool) Option {
+	return func(r *Reconciler) error {
+		r.stripManifestFromStatus = strip
 		return nil
 	}
 }
@@ -528,7 +541,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.
 	if errors.Is(err, driver.ErrReleaseNotFound) {
 		u.UpdateStatus(updater.EnsureCondition(conditions.Deployed(corev1.ConditionFalse, "", "")))
 	} else if err == nil {
-		ensureDeployedRelease(&u, rel)
+		r.ensureDeployedRelease(&u, rel)
 	}
 	u.UpdateStatus(updater.EnsureCondition(conditions.Initialized(corev1.ConditionTrue, "", "")))
 
@@ -615,7 +628,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.
 		}
 	}
 
-	ensureDeployedRelease(&u, rel)
+	r.ensureDeployedRelease(&u, rel)
 	u.UpdateStatus(
 		updater.EnsureCondition(conditions.ReleaseFailed(corev1.ConditionFalse, "", "")),
 		updater.EnsureCondition(conditions.Irreconcilable(corev1.ConditionFalse, "", "")),
@@ -943,7 +956,7 @@ func (r *Reconciler) setupWatches(mgr ctrl.Manager, c controller.Controller) err
 	return nil
 }
 
-func ensureDeployedRelease(u *updater.Updater, rel *release.Release) {
+func (r *Reconciler) ensureDeployedRelease(u *updater.Updater, rel *release.Release) {
 	reason := conditions.ReasonInstallSuccessful
 	message := "release was successfully installed"
 	if rel.Version > 1 {
@@ -953,6 +966,13 @@ func ensureDeployedRelease(u *updater.Updater, rel *release.Release) {
 	if rel.Info != nil && len(rel.Info.Notes) > 0 {
 		message = rel.Info.Notes
 	}
+
+	if r.stripManifestFromStatus {
+		relCopy := *rel
+		relCopy.Manifest = ""
+		rel = &relCopy
+	}
+
 	u.Update(updater.EnsureFinalizer(uninstallFinalizer))
 	u.UpdateStatus(
 		updater.EnsureCondition(conditions.Deployed(corev1.ConditionTrue, reason, message)),

--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -154,6 +154,16 @@ var _ = Describe("Reconciler", func() {
 				Expect(r.skipDependentWatches).To(Equal(true))
 			})
 		})
+		var _ = Describe("StripManifestFromStatus", func() {
+			It("should set to false", func() {
+				Expect(StripManifestFromStatus(false)(r)).To(Succeed())
+				Expect(r.stripManifestFromStatus).To(Equal(false))
+			})
+			It("should set to true", func() {
+				Expect(StripManifestFromStatus(true)(r)).To(Succeed())
+				Expect(r.stripManifestFromStatus).To(Equal(true))
+			})
+		})
 		var _ = Describe("WithMaxConcurrentReconciles", func() {
 			It("should set the reconciler max concurrent reconciled", func() {
 				Expect(WithMaxConcurrentReconciles(1)(r)).To(Succeed())


### PR DESCRIPTION
By default, the `status.deployedRelease.manifest` field contains the entire manifest, i.e., all the YAMLs rendered from Helm. This can easily cause sensitive data that should only be stored in a secret to end up in the status field.

Therefore, add an option to suppress the manifest from the release status.