### PR TITLE
Allow setting up dependent watches for some resource types, even if dependent watches are disabled

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,5 @@
+upstream-triage:
+  - "./*"
 area/main-binary:
   - 'main.go'
   - 'internal/**/*'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,7 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - '**'
-  pull_request:
-    branches: [ main ]
+  - push
 
 jobs:
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,13 +1,14 @@
 name: Deploy
 
-on:
-  push:
-    branches:
-      - '**'
-    tags:
-      - 'v*'
-  pull_request:
-    branches: [ main ]
+# Disabled as we don't need docker images to use the helm-operator as a library.
+#on:
+#  push:
+#    branches:
+#      - '**'
+#    tags:
+#      - 'v*'
+#  pull_request:
+#    branches: [ main ]
 
 jobs:
   goreleaser:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ by mapping the [values](https://helm.sh/docs/chart_template_guide/values_files/)
 
 For creating a [Level II+](https://sdk.operatorframework.io/docs/advanced-topics/operator-capabilities/operator-capabilities/) operator 
 that reuses an already existing Helm chart, we need a [hybrid](https://github.com/operator-framework/operator-sdk/issues/670)
-between the Go and Helm operator types is.
+between the Go and Helm operator types.
 
 The hybrid approach allows adding customizations to the Helm operator, such as:
 - value mapping based on cluster state, or 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,46 @@
 # helm-operator
 
-[![Build Status](https://github.com/joelanford/helm-operator/workflows/CI/badge.svg?branch=master)
-[![Coverage Status](https://coveralls.io/repos/github/joelanford/helm-operator/badge.svg?branch=master)](https://coveralls.io/github/joelanford/helm-operator?branch=master)
+[![Build Status](https://github.com/stackrox/helm-operator/workflows/CI/badge.svg?branch=main)
 
 Experimental refactoring of the operator-framework's helm operator
+
+## Why a fork?
+
+Initially the Helm operator type was designed to automate Helm chart operations
+by mapping the [values](https://helm.sh/docs/chart_template_guide/values_files/) of a Helm chart exactly to a 
+`CustomResourceDefinition` and defining its watched resources in a `watches.yaml` 
+[configuration](https://sdk.operatorframework.io/docs/building-operators/helm/tutorial/#watch-the-nginx-cr).
+
+To write a [Level II+](https://sdk.operatorframework.io/docs/advanced-topics/operator-capabilities/operator-capabilities/) operator 
+which reuses an already existing Helm chart a [hybrid](https://github.com/operator-framework/operator-sdk/issues/670)
+between the Go and Helm operator type is necessary.
+
+The hybrid approach allows to add customizations to the Helm operator like value mapping based on cluster state or
+executing code in on specific events.
+
+## Quickstart
+
+Add this module as a replace directive to your `go.mod`:
+
+```
+go mod edit -replace=github.com/joelanford/helm-operator=github.com/stackrox/helm-operator@main
+```
+
+Example:
+
+```
+chart, err := loader.Load("path/to/chart")
+if err != nil {
+    panic(err)
+}
+
+reconciler := reconciler.New(
+    reconciler.WithChart(*chart),
+    reconciler.WithGroupVersionKind(gvk),
+)
+
+if err := reconciler.SetupWithManager(mgr); err != nil {
+    panic(fmt.Sprintf("unable to create reconciler: %s", err))
+}
+```
+

--- a/README.md
+++ b/README.md
@@ -1,46 +1,47 @@
 # helm-operator
 
-[![Build Status](https://github.com/stackrox/helm-operator/workflows/CI/badge.svg?branch=main)
+![Build Status](https://github.com/stackrox/helm-operator/workflows/CI/badge.svg?branch=main)
 
-Experimental refactoring of the operator-framework's helm operator
+Experimental refactoring of the operator-framework's helm operator.
 
 ## Why a fork?
 
-Initially the Helm operator type was designed to automate Helm chart operations
+The Helm operator type automates Helm chart operations
 by mapping the [values](https://helm.sh/docs/chart_template_guide/values_files/) of a Helm chart exactly to a 
 `CustomResourceDefinition` and defining its watched resources in a `watches.yaml` 
-[configuration](https://sdk.operatorframework.io/docs/building-operators/helm/tutorial/#watch-the-nginx-cr).
+[configuration](https://sdk.operatorframework.io/docs/building-operators/helm/tutorial/#watch-the-nginx-cr) file.
 
-To write a [Level II+](https://sdk.operatorframework.io/docs/advanced-topics/operator-capabilities/operator-capabilities/) operator 
-which reuses an already existing Helm chart a [hybrid](https://github.com/operator-framework/operator-sdk/issues/670)
-between the Go and Helm operator type is necessary.
+For creating a [Level II+](https://sdk.operatorframework.io/docs/advanced-topics/operator-capabilities/operator-capabilities/) operator 
+that reuses an already existing Helm chart, we need a [hybrid](https://github.com/operator-framework/operator-sdk/issues/670)
+between the Go and Helm operator types is.
 
-The hybrid approach allows to add customizations to the Helm operator like value mapping based on cluster state or
-executing code in on specific events.
+The hybrid approach allows adding customizations to the Helm operator, such as:
+- value mapping based on cluster state, or 
+- executing code in specific events.
 
-## Quickstart
+## Quick start
 
-Add this module as a replace directive to your `go.mod`:
+- Add this module as a replace directive to your `go.mod`:
 
-```
-go mod edit -replace=github.com/joelanford/helm-operator=github.com/stackrox/helm-operator@main
-```
+  ```
+  go mod edit -replace=github.com/joelanford/helm-operator=github.com/stackrox/helm-operator@main
+  ```
 
-Example:
+  For example:
 
-```
-chart, err := loader.Load("path/to/chart")
-if err != nil {
-    panic(err)
-}
+  ```go
+  chart, err := loader.Load("path/to/chart")
+  if err != nil {
+     panic(err)
+  }
 
-reconciler := reconciler.New(
-    reconciler.WithChart(*chart),
-    reconciler.WithGroupVersionKind(gvk),
-)
+  reconciler := reconciler.New(
+     reconciler.WithChart(*chart),
+     reconciler.WithGroupVersionKind(gvk),
+  )
 
-if err := reconciler.SetupWithManager(mgr); err != nil {
-    panic(fmt.Sprintf("unable to create reconciler: %s", err))
-}
-```
+  if err := reconciler.SetupWithManager(mgr); err != nil {
+     panic(fmt.Sprintf("unable to create reconciler: %s", err))
+  }
+  ```
 

--- a/internal/cmd/run/cmd.go
+++ b/internal/cmd/run/cmd.go
@@ -169,7 +169,7 @@ func (r *run) run(cmd *cobra.Command) {
 			os.Exit(1)
 		}
 
-		if err := r.SetupWithManager(mgr); err != nil {
+		if err := r.SetupWithManager(mgr, reconciler.SetupOpts{}); err != nil {
 			log.Error(err, "unable to create controller", "controller", "Helm")
 			os.Exit(1)
 		}

--- a/pkg/annotation/annotation.go
+++ b/pkg/annotation/annotation.go
@@ -14,6 +14,30 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package annotation allows to set custom install, upgrade or uninstall options on custom resource objects with annotations.
+// To create custom annotations implement the Install, Upgrade or Uninstall interface.
+//
+// Example:
+//
+// To disable hooks based on annotations the InstallDisableHooks is passed to the reconciler as an option.
+//
+//    r, err := reconciler.New(
+//	    reconciler.WithChart(*w.Chart),
+//	    reconciler.WithGroupVersionKind(w.GroupVersionKind),
+//	    reconciler.WithInstallAnnotations(annotation.InstallDisableHooks{}),
+//	  )
+//
+// If the reconciler detects an annotation named "helm.sdk.operatorframework.io/install-disable-hooks"
+// on the watched custom resource, it sets the install.DisableHooks option to the annotations value. For more information
+// take a look at the InstallDisableHooks.InstallOption method.
+//
+//   kind: OperatorHelmKind
+//   apiVersion: test.example.com/v1
+//   metadata:
+//     name: nginx-sample
+//     annotations:
+//       "helm.sdk.operatorframework.io/install-disable-hooks": true
+//
 package annotation
 
 import (
@@ -30,26 +54,23 @@ var (
 	DefaultUninstallAnnotations = []Uninstall{UninstallDescription{}, UninstallDisableHooks{}}
 )
 
+// Install configures an install annotation.
 type Install interface {
 	Name() string
 	InstallOption(string) helmclient.InstallOption
 }
 
+// Upgrade configures an upgrade annotation.
 type Upgrade interface {
 	Name() string
 	UpgradeOption(string) helmclient.UpgradeOption
 }
 
+// Uninstall configures an uninstall annotation.
 type Uninstall interface {
 	Name() string
 	UninstallOption(string) helmclient.UninstallOption
 }
-
-type InstallDisableHooks struct {
-	CustomName string
-}
-
-var _ Install = &InstallDisableHooks{}
 
 const (
 	defaultDomain                    = "helm.sdk.operatorframework.io"
@@ -63,6 +84,12 @@ const (
 	defaultUpgradeDescriptionName   = defaultDomain + "/upgrade-description"
 	defaultUninstallDescriptionName = defaultDomain + "/uninstall-description"
 )
+
+type InstallDisableHooks struct {
+	CustomName string
+}
+
+var _ Install = &InstallDisableHooks{}
 
 func (i InstallDisableHooks) Name() string {
 	if i.CustomName != "" {

--- a/pkg/client/actionclient.go
+++ b/pkg/client/actionclient.go
@@ -62,6 +62,7 @@ type ActionInterface interface {
 	Get(name string, opts ...GetOption) (*release.Release, error)
 	Install(name, namespace string, chrt *chart.Chart, vals map[string]interface{}, opts ...InstallOption) (*release.Release, error)
 	Upgrade(name, namespace string, chrt *chart.Chart, vals map[string]interface{}, opts ...UpgradeOption) (*release.Release, error)
+	MarkFailed(release *release.Release, reason string) error
 	Uninstall(name string, opts ...UninstallOption) (*release.UninstallReleaseResponse, error)
 	Reconcile(rel *release.Release) error
 }
@@ -178,6 +179,14 @@ func (c *actionClient) Upgrade(name, namespace string, chrt *chart.Chart, vals m
 		return nil, err
 	}
 	return rel, nil
+}
+
+func (c *actionClient) MarkFailed(rel *release.Release, reason string) error {
+	infoCopy := *rel.Info
+	releaseCopy := *rel
+	releaseCopy.Info = &infoCopy
+	releaseCopy.SetStatus(release.StatusFailed, reason)
+	return c.conf.Releases.Update(&releaseCopy)
 }
 
 func (c *actionClient) Uninstall(name string, opts ...UninstallOption) (*release.UninstallReleaseResponse, error) {

--- a/pkg/client/actionclient.go
+++ b/pkg/client/actionclient.go
@@ -163,6 +163,7 @@ func (c *actionClient) Upgrade(name, namespace string, chrt *chart.Chart, vals m
 		if rel != nil {
 			rollback := action.NewRollback(c.conf)
 			rollback.Force = true
+			rollback.MaxHistory = upgrade.MaxHistory
 
 			// As of Helm 2.13, if Upgrade returns a non-nil release, that
 			// means the release was also recorded in the release store.

--- a/pkg/extensions/types.go
+++ b/pkg/extensions/types.go
@@ -1,0 +1,12 @@
+package extensions
+
+import (
+	"context"
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// ReconcileExtension is an arbitrary extension that can be implemented to run either before
+// or after the main Helm reconciliation action.
+// An error returned by a ReconcileExtension will cause the Reconcile to fail, unlike a hook error.
+type ReconcileExtension func(context.Context, *unstructured.Unstructured, logr.Logger) error

--- a/pkg/extensions/types.go
+++ b/pkg/extensions/types.go
@@ -2,11 +2,16 @@ package extensions
 
 import (
 	"context"
+
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
+// UpdateStatusFunc is a function that updates an unstructured status. If the status has been modified,
+// true must be returned, false otherwise.
+type UpdateStatusFunc func(*unstructured.Unstructured) bool
+
 // ReconcileExtension is an arbitrary extension that can be implemented to run either before
 // or after the main Helm reconciliation action.
 // An error returned by a ReconcileExtension will cause the Reconcile to fail, unlike a hook error.
-type ReconcileExtension func(context.Context, *unstructured.Unstructured, logr.Logger) error
+type ReconcileExtension func(context.Context, *unstructured.Unstructured, func(UpdateStatusFunc), logr.Logger) error

--- a/pkg/reconciler/internal/conditions/conditions.go
+++ b/pkg/reconciler/internal/conditions/conditions.go
@@ -41,6 +41,7 @@ const (
 	ReasonUpgradeError             = status.ConditionReason("UpgradeError")
 	ReasonReconcileError           = status.ConditionReason("ReconcileError")
 	ReasonUninstallError           = status.ConditionReason("UninstallError")
+	ReasonPendingError             = status.ConditionReason("PendingError")
 )
 
 func Initialized(stat corev1.ConditionStatus, reason status.ConditionReason, message interface{}) status.Condition {

--- a/pkg/reconciler/internal/hook/hook_test.go
+++ b/pkg/reconciler/internal/hook/hook_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Hook", func() {
 				rel = &release.Release{
 					Manifest: strings.Join([]string{rsOwnerNamespace}, "---\n"),
 				}
-				drw = internalhook.NewDependentResourceWatcher(c, rm)
+				drw = internalhook.NewDependentResourceWatcher(c, rm, true)
 			})
 			It("should fail with an invalid release manifest", func() {
 				rel.Manifest = "---\nfoobar"
@@ -110,7 +110,7 @@ var _ = Describe("Hook", func() {
 				rel = &release.Release{
 					Manifest: strings.Join([]string{clusterRole, clusterRole, rsOwnerNamespace, rsOwnerNamespace}, "---\n"),
 				}
-				drw = internalhook.NewDependentResourceWatcher(c, rm)
+				drw = internalhook.NewDependentResourceWatcher(c, rm, true)
 				Expect(drw.Exec(owner, *rel, log)).To(Succeed())
 				Expect(c.WatchCalls).To(HaveLen(2))
 				Expect(c.WatchCalls[0].Handler).To(BeAssignableToTypeOf(&handler.EnqueueRequestForOwner{}))
@@ -133,7 +133,7 @@ var _ = Describe("Hook", func() {
 					rel = &release.Release{
 						Manifest: strings.Join([]string{rsOwnerNamespace, ssOtherNamespace}, "---\n"),
 					}
-					drw = internalhook.NewDependentResourceWatcher(c, rm)
+					drw = internalhook.NewDependentResourceWatcher(c, rm, true)
 					Expect(drw.Exec(owner, *rel, log)).To(Succeed())
 					Expect(c.WatchCalls).To(HaveLen(2))
 					Expect(c.WatchCalls[0].Handler).To(BeAssignableToTypeOf(&handler.EnqueueRequestForOwner{}))
@@ -144,7 +144,7 @@ var _ = Describe("Hook", func() {
 					rel = &release.Release{
 						Manifest: strings.Join([]string{clusterRole, clusterRoleBinding}, "---\n"),
 					}
-					drw = internalhook.NewDependentResourceWatcher(c, rm)
+					drw = internalhook.NewDependentResourceWatcher(c, rm, true)
 					Expect(drw.Exec(owner, *rel, log)).To(Succeed())
 					Expect(c.WatchCalls).To(HaveLen(2))
 					Expect(c.WatchCalls[0].Handler).To(BeAssignableToTypeOf(&handler.EnqueueRequestForOwner{}))
@@ -154,7 +154,7 @@ var _ = Describe("Hook", func() {
 					rel = &release.Release{
 						Manifest: strings.Join([]string{rsOwnerNamespaceWithKeep, ssOtherNamespaceWithKeep, clusterRoleWithKeep, clusterRoleBindingWithKeep}, "---\n"),
 					}
-					drw = internalhook.NewDependentResourceWatcher(c, rm)
+					drw = internalhook.NewDependentResourceWatcher(c, rm, true)
 					Expect(drw.Exec(owner, *rel, log)).To(Succeed())
 					Expect(c.WatchCalls).To(HaveLen(4))
 					Expect(c.WatchCalls[0].Handler).To(BeAssignableToTypeOf(&sdkhandler.EnqueueRequestForAnnotation{}))
@@ -181,7 +181,7 @@ var _ = Describe("Hook", func() {
 					rel = &release.Release{
 						Manifest: strings.Join([]string{rsOwnerNamespace}, "---\n"),
 					}
-					drw = internalhook.NewDependentResourceWatcher(c, rm)
+					drw = internalhook.NewDependentResourceWatcher(c, rm, true)
 					Expect(drw.Exec(owner, *rel, log)).To(Succeed())
 					Expect(c.WatchCalls).To(HaveLen(1))
 					Expect(c.WatchCalls[0].Handler).To(BeAssignableToTypeOf(&handler.EnqueueRequestForOwner{}))
@@ -190,7 +190,7 @@ var _ = Describe("Hook", func() {
 					rel = &release.Release{
 						Manifest: strings.Join([]string{clusterRole}, "---\n"),
 					}
-					drw = internalhook.NewDependentResourceWatcher(c, rm)
+					drw = internalhook.NewDependentResourceWatcher(c, rm, true)
 					Expect(drw.Exec(owner, *rel, log)).To(Succeed())
 					Expect(c.WatchCalls).To(HaveLen(1))
 					Expect(c.WatchCalls[0].Handler).To(BeAssignableToTypeOf(&sdkhandler.EnqueueRequestForAnnotation{}))
@@ -199,7 +199,7 @@ var _ = Describe("Hook", func() {
 					rel = &release.Release{
 						Manifest: strings.Join([]string{ssOtherNamespace}, "---\n"),
 					}
-					drw = internalhook.NewDependentResourceWatcher(c, rm)
+					drw = internalhook.NewDependentResourceWatcher(c, rm, true)
 					Expect(drw.Exec(owner, *rel, log)).To(Succeed())
 					Expect(c.WatchCalls).To(HaveLen(1))
 					Expect(c.WatchCalls[0].Handler).To(BeAssignableToTypeOf(&sdkhandler.EnqueueRequestForAnnotation{}))
@@ -208,7 +208,7 @@ var _ = Describe("Hook", func() {
 					rel = &release.Release{
 						Manifest: strings.Join([]string{rsOwnerNamespaceWithKeep, ssOtherNamespaceWithKeep, clusterRoleWithKeep}, "---\n"),
 					}
-					drw = internalhook.NewDependentResourceWatcher(c, rm)
+					drw = internalhook.NewDependentResourceWatcher(c, rm, true)
 					Expect(drw.Exec(owner, *rel, log)).To(Succeed())
 					Expect(c.WatchCalls).To(HaveLen(3))
 					Expect(c.WatchCalls[0].Handler).To(BeAssignableToTypeOf(&sdkhandler.EnqueueRequestForAnnotation{}))

--- a/pkg/reconciler/internal/updater/updater.go
+++ b/pkg/reconciler/internal/updater/updater.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/joelanford/helm-operator/pkg/extensions"
 	"github.com/joelanford/helm-operator/pkg/internal/sdk/controllerutil"
 	"github.com/joelanford/helm-operator/pkg/internal/sdk/status"
 )
@@ -53,6 +54,21 @@ func (u *Updater) UpdateStatus(fs ...UpdateStatusFunc) {
 	u.updateStatusFuncs = append(u.updateStatusFuncs, fs...)
 }
 
+func (u *Updater) UpdateStatusCustom(f extensions.UpdateStatusFunc) {
+	updateFn := func(status *helmAppStatus) bool {
+		status.updateStatusObject()
+
+		unstructuredStatus := unstructured.Unstructured{Object: status.StatusObject}
+		if !f(&unstructuredStatus) {
+			return false
+		}
+		_ = runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredStatus.Object, status)
+		status.StatusObject = unstructuredStatus.Object
+		return true
+	}
+	u.UpdateStatus(updateFn)
+}
+
 func (u *Updater) Apply(ctx context.Context, obj *unstructured.Unstructured) error {
 	backoff := retry.DefaultRetry
 
@@ -66,11 +82,8 @@ func (u *Updater) Apply(ctx context.Context, obj *unstructured.Unstructured) err
 			needsStatusUpdate = f(st) || needsStatusUpdate
 		}
 		if needsStatusUpdate {
-			uSt, err := runtime.DefaultUnstructuredConverter.ToUnstructured(st)
-			if err != nil {
-				return err
-			}
-			obj.Object["status"] = uSt
+			st.updateStatusObject()
+			obj.Object["status"] = st.StatusObject
 			return u.client.Status().Update(ctx, obj)
 		}
 		return nil
@@ -149,8 +162,23 @@ func RemoveDeployedRelease() UpdateStatusFunc {
 }
 
 type helmAppStatus struct {
+	StatusObject map[string]interface{} `json:"-"`
+
 	Conditions      status.Conditions `json:"conditions"`
 	DeployedRelease *helmAppRelease   `json:"deployedRelease,omitempty"`
+}
+
+func (s *helmAppStatus) updateStatusObject() {
+	unstructuredHelmAppStatus, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(s)
+	if s.StatusObject == nil {
+		s.StatusObject = make(map[string]interface{})
+	}
+	s.StatusObject["conditions"] = unstructuredHelmAppStatus["conditions"]
+	if deployedRelease := unstructuredHelmAppStatus["deployedRelease"]; deployedRelease != nil {
+		s.StatusObject["deployedRelease"] = deployedRelease
+	} else {
+		delete(s.StatusObject, "deployedRelease")
+	}
 }
 
 type helmAppRelease struct {
@@ -175,6 +203,7 @@ func statusFor(obj *unstructured.Unstructured) *helmAppStatus {
 	case map[string]interface{}:
 		out := &helmAppStatus{}
 		_ = runtime.DefaultUnstructuredConverter.FromUnstructured(s, out)
+		out.StatusObject = s
 		return out
 	default:
 		return &helmAppStatus{}

--- a/pkg/reconciler/internal/values/values.go
+++ b/pkg/reconciler/internal/values/values.go
@@ -68,3 +68,11 @@ func (v *Values) ApplyOverrides(in map[string]string) error {
 }
 
 var DefaultMapper = values.MapperFunc(func(v chartutil.Values) chartutil.Values { return v })
+
+var DefaultTranslator = values.TranslatorFunc(func(u *unstructured.Unstructured) (chartutil.Values, error) {
+	internalValues, err := FromUnstructured(u)
+	if err != nil {
+		return chartutil.Values{}, err
+	}
+	return internalValues.Map(), err
+})

--- a/pkg/reconciler/internal/values/values.go
+++ b/pkg/reconciler/internal/values/values.go
@@ -17,6 +17,7 @@ limitations under the License.
 package values
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -69,7 +70,7 @@ func (v *Values) ApplyOverrides(in map[string]string) error {
 
 var DefaultMapper = values.MapperFunc(func(v chartutil.Values) chartutil.Values { return v })
 
-var DefaultTranslator = values.TranslatorFunc(func(u *unstructured.Unstructured) (chartutil.Values, error) {
+var DefaultTranslator = values.TranslatorFunc(func(ctx context.Context, u *unstructured.Unstructured) (chartutil.Values, error) {
 	internalValues, err := FromUnstructured(u)
 	if err != nil {
 		return chartutil.Values{}, err

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -546,7 +546,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.
 	u.UpdateStatus(updater.EnsureCondition(conditions.Initialized(corev1.ConditionTrue, "", "")))
 
 	for _, ext := range r.preExtensions {
-		if err := ext(ctx, obj, r.log); err != nil {
+		if err := ext(ctx, obj, u.UpdateStatusCustom, r.log); err != nil {
 			u.UpdateStatus(
 				updater.EnsureCondition(conditions.Irreconcilable(corev1.ConditionTrue, conditions.ReasonReconcileError, err)),
 				updater.EnsureConditionUnknown(conditions.TypeReleaseFailed),
@@ -619,7 +619,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.
 	}
 
 	for _, ext := range r.postExtensions {
-		if err := ext(ctx, obj, r.log); err != nil {
+		if err := ext(ctx, obj, u.UpdateStatusCustom, r.log); err != nil {
 			u.UpdateStatus(
 				updater.EnsureCondition(conditions.Irreconcilable(corev1.ConditionTrue, conditions.ReasonReconcileError, err)),
 				updater.EnsureConditionUnknown(conditions.TypeReleaseFailed),
@@ -868,7 +868,7 @@ func (r *Reconciler) doUninstall(ctx context.Context, actionClient helmclient.Ac
 	}
 
 	for _, ext := range r.postExtensions {
-		if err := ext(ctx, obj, r.log); err != nil {
+		if err := ext(ctx, obj, u.UpdateStatusCustom, r.log); err != nil {
 			u.UpdateStatus(
 				updater.EnsureCondition(conditions.Irreconcilable(corev1.ConditionTrue, conditions.ReasonReconcileError, err)),
 				updater.EnsureConditionUnknown(conditions.TypeReleaseFailed),

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -471,7 +471,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.
 		return ctrl.Result{}, err
 	}
 
-	vals, err := r.getValues(obj)
+	vals, err := r.getValues(ctx, obj)
 	if err != nil {
 		u.UpdateStatus(
 			updater.EnsureCondition(conditions.Irreconcilable(corev1.ConditionTrue, conditions.ReasonErrorGettingValues, err)),
@@ -534,8 +534,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.
 	return ctrl.Result{RequeueAfter: r.reconcilePeriod}, nil
 }
 
-func (r *Reconciler) getValues(obj *unstructured.Unstructured) (chartutil.Values, error) {
-	vals, err := r.valueTranslator.Translate(obj)
+func (r *Reconciler) getValues(ctx context.Context, obj *unstructured.Unstructured) (chartutil.Values, error) {
+	vals, err := r.valueTranslator.Translate(ctx, obj)
 	if err != nil {
 		return chartutil.Values{}, err
 	}

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -78,6 +78,7 @@ type Reconciler struct {
 	skipDependentWatches    bool
 	maxConcurrentReconciles int
 	reconcilePeriod         time.Duration
+	maxHistory              int
 
 	annotSetupOnce       sync.Once
 	annotations          map[string]struct{}
@@ -287,6 +288,18 @@ func WithReconcilePeriod(rp time.Duration) Option {
 			return errors.New("reconcile period must not be negative")
 		}
 		r.reconcilePeriod = rp
+		return nil
+	}
+}
+
+// WithMaxReleaseHistory specifies the maximum size of the Helm release history maintained
+// on upgrades/rollbacks. Zero (default) means unlimited.
+func WithMaxReleaseHistory(maxHistory int) Option {
+	return func(r *Reconciler) error {
+		if maxHistory < 0 {
+			return errors.New("maximum Helm release history size must not be negative")
+		}
+		r.maxHistory = maxHistory
 		return nil
 	}
 }
@@ -666,6 +679,12 @@ func (r *Reconciler) getReleaseState(client helmclient.ActionInterface, obj meta
 	}
 
 	var opts []helmclient.UpgradeOption
+	if r.maxHistory > 0 {
+		opts = append(opts, func(u *action.Upgrade) error {
+			u.MaxHistory = r.maxHistory
+			return nil
+		})
+	}
 	for name, annot := range r.upgradeAnnotations {
 		if v, ok := obj.GetAnnotations()[name]; ok {
 			opts = append(opts, annot.UpgradeOption(v))
@@ -710,6 +729,12 @@ func (r *Reconciler) doInstall(actionClient helmclient.ActionInterface, u *updat
 
 func (r *Reconciler) doUpgrade(actionClient helmclient.ActionInterface, u *updater.Updater, obj *unstructured.Unstructured, vals map[string]interface{}, log logr.Logger) (*release.Release, error) {
 	var opts []helmclient.UpgradeOption
+	if r.maxHistory > 0 {
+		opts = append(opts, func(u *action.Upgrade) error {
+			u.MaxHistory = r.maxHistory
+			return nil
+		})
+	}
 	for name, annot := range r.upgradeAnnotations {
 		if v, ok := obj.GetAnnotations()[name]; ok {
 			opts = append(opts, annot.UpgradeOption(v))

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -46,6 +46,7 @@ import (
 
 	"github.com/joelanford/helm-operator/pkg/annotation"
 	helmclient "github.com/joelanford/helm-operator/pkg/client"
+	"github.com/joelanford/helm-operator/pkg/extensions"
 	"github.com/joelanford/helm-operator/pkg/hook"
 	"github.com/joelanford/helm-operator/pkg/internal/sdk/controllerutil"
 	"github.com/joelanford/helm-operator/pkg/reconciler/internal/conditions"
@@ -66,6 +67,9 @@ type Reconciler struct {
 	eventRecorder      record.EventRecorder
 	preHooks           []hook.PreHook
 	postHooks          []hook.PostHook
+
+	preExtensions  []extensions.ReconcileExtension
+	postExtensions []extensions.ReconcileExtension
 
 	log                     logr.Logger
 	gvk                     *schema.GroupVersionKind
@@ -360,11 +364,41 @@ func WithPreHook(h hook.PreHook) Option {
 	}
 }
 
+// WithPreExtension is an Option that configures the reconciler to run the given
+// extension before performing any reconciliation steps (including values translation).
+// An error returned from the extension will cause the reconciliation to fail.
+// This should be preferred to WithPreHook in most cases, except for when the logic
+// depends on the translated Helm values.
+// The extension will be invoked with the raw object state; meaning it needs to be careful
+// to check for existence of the deletionTimestamp field.
+func WithPreExtension(e extensions.ReconcileExtension) Option {
+	return func(r *Reconciler) error {
+		r.preExtensions = append(r.preExtensions, e)
+		return nil
+	}
+}
+
 // WithPostHook is an Option that configures the reconciler to run the given
 // PostHook just after performing any non-uninstall release actions.
 func WithPostHook(h hook.PostHook) Option {
 	return func(r *Reconciler) error {
 		r.postHooks = append(r.postHooks, h)
+		return nil
+	}
+}
+
+// WithPostExtension is an Option that configures the reconciler to run the given
+// extension after performing any reconciliation steps (including uninstall of the release,
+// but not removal of the finalizer).
+// An error returned from the extension will cause the reconciliation to fail, which might
+// prevent the finalizer from getting removed.
+// This should be preferred to WithPostHook in most cases, except for when the logic
+// depends on the translated Helm values.
+// The extension will be invoked with the raw object state; meaning it needs to be careful
+// to check for existence of the deletionTimestamp field.
+func WithPostExtension(e extensions.ReconcileExtension) Option {
+	return func(r *Reconciler) error {
+		r.postExtensions = append(r.postExtensions, e)
 		return nil
 	}
 }
@@ -472,6 +506,16 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.
 	}
 	u.UpdateStatus(updater.EnsureCondition(conditions.Initialized(corev1.ConditionTrue, "", "")))
 
+	for _, ext := range r.preExtensions {
+		if err := ext(ctx, obj, r.log); err != nil {
+			u.UpdateStatus(
+				updater.EnsureCondition(conditions.Irreconcilable(corev1.ConditionTrue, conditions.ReasonReconcileError, err)),
+				updater.EnsureConditionUnknown(conditions.TypeReleaseFailed),
+			)
+			return ctrl.Result{}, err
+		}
+	}
+
 	if obj.GetDeletionTimestamp() != nil {
 		err := r.handleDeletion(ctx, actionClient, obj, log)
 		return ctrl.Result{}, err
@@ -531,6 +575,16 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.
 		}
 	}
 
+	for _, ext := range r.postExtensions {
+		if err := ext(ctx, obj, r.log); err != nil {
+			u.UpdateStatus(
+				updater.EnsureCondition(conditions.Irreconcilable(corev1.ConditionTrue, conditions.ReasonReconcileError, err)),
+				updater.EnsureConditionUnknown(conditions.TypeReleaseFailed),
+			)
+			return ctrl.Result{}, err
+		}
+	}
+
 	ensureDeployedRelease(&u, rel)
 	u.UpdateStatus(
 		updater.EnsureCondition(conditions.ReleaseFailed(corev1.ConditionFalse, "", "")),
@@ -586,7 +640,7 @@ func (r *Reconciler) handleDeletion(ctx context.Context, actionClient helmclient
 				err = applyErr
 			}
 		}()
-		return r.doUninstall(actionClient, &uninstallUpdater, obj, log)
+		return r.doUninstall(ctx, actionClient, &uninstallUpdater, obj, log)
 	}(); err != nil {
 		return err
 	}
@@ -703,7 +757,7 @@ func (r *Reconciler) doReconcile(actionClient helmclient.ActionInterface, u *upd
 	return nil
 }
 
-func (r *Reconciler) doUninstall(actionClient helmclient.ActionInterface, u *updater.Updater, obj *unstructured.Unstructured, log logr.Logger) error {
+func (r *Reconciler) doUninstall(ctx context.Context, actionClient helmclient.ActionInterface, u *updater.Updater, obj *unstructured.Unstructured, log logr.Logger) error {
 	var opts []helmclient.UninstallOption
 	for name, annot := range r.uninstallAnnotations {
 		if v, ok := obj.GetAnnotations()[name]; ok {
@@ -723,6 +777,17 @@ func (r *Reconciler) doUninstall(actionClient helmclient.ActionInterface, u *upd
 	} else {
 		log.Info("Release uninstalled", "name", resp.Release.Name, "version", resp.Release.Version)
 	}
+
+	for _, ext := range r.postExtensions {
+		if err := ext(ctx, obj, r.log); err != nil {
+			u.UpdateStatus(
+				updater.EnsureCondition(conditions.Irreconcilable(corev1.ConditionTrue, conditions.ReasonReconcileError, err)),
+				updater.EnsureConditionUnknown(conditions.TypeReleaseFailed),
+			)
+			return err
+		}
+	}
+
 	u.Update(updater.RemoveFinalizer(uninstallFinalizer))
 	u.UpdateStatus(
 		updater.EnsureCondition(conditions.ReleaseFailed(corev1.ConditionFalse, "", "")),

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -78,6 +78,7 @@ type Reconciler struct {
 	skipDependentWatches    bool
 	maxConcurrentReconciles int
 	reconcilePeriod         time.Duration
+	markFailedAfter         time.Duration
 	maxHistory              int
 
 	annotSetupOnce       sync.Once
@@ -300,6 +301,18 @@ func WithMaxReleaseHistory(maxHistory int) Option {
 			return errors.New("maximum Helm release history size must not be negative")
 		}
 		r.maxHistory = maxHistory
+		return nil
+	}
+}
+
+// WithMarkFailedAfter specifies the duration after which the reconciler will mark a release in a pending (locked)
+// state as false in order to allow rolling forward.
+func WithMarkFailedAfter(duration time.Duration) Option {
+	return func(r *Reconciler) error {
+		if duration < 0 {
+			return errors.New("auto-rollback after duration must not be negative")
+		}
+		r.markFailedAfter = duration
 		return nil
 	}
 }
@@ -553,6 +566,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.
 		)
 		return ctrl.Result{}, err
 	}
+	if state == statePending {
+		return r.handlePending(actionClient, rel, &u, log)
+	}
+
 	u.UpdateStatus(updater.EnsureCondition(conditions.Irreconcilable(corev1.ConditionFalse, "", "")))
 
 	for _, h := range r.preHooks {
@@ -630,6 +647,7 @@ const (
 	stateNeedsInstall helmReleaseState = "needs install"
 	stateNeedsUpgrade helmReleaseState = "needs upgrade"
 	stateUnchanged    helmReleaseState = "unchanged"
+	statePending      helmReleaseState = "pending"
 	stateError        helmReleaseState = "error"
 )
 
@@ -676,6 +694,10 @@ func (r *Reconciler) getReleaseState(client helmclient.ActionInterface, obj meta
 
 	if errors.Is(err, driver.ErrReleaseNotFound) {
 		return nil, stateNeedsInstall, nil
+	}
+
+	if currentRelease.Info != nil && currentRelease.Info.Status.IsPending() {
+		return currentRelease, statePending, nil
 	}
 
 	var opts []helmclient.UpgradeOption
@@ -753,6 +775,35 @@ func (r *Reconciler) doUpgrade(actionClient helmclient.ActionInterface, u *updat
 
 	log.Info("Release upgraded", "name", rel.Name, "version", rel.Version)
 	return rel, nil
+}
+
+func (r *Reconciler) handlePending(actionClient helmclient.ActionInterface, rel *release.Release, u *updater.Updater, log logr.Logger) (ctrl.Result, error) {
+	err := r.doHandlePending(actionClient, rel, log)
+	if err == nil {
+		err = errors.New("unknown error handling pending release")
+	}
+	u.UpdateStatus(
+		updater.EnsureCondition(conditions.Irreconcilable(corev1.ConditionTrue, conditions.ReasonPendingError, err)))
+	return ctrl.Result{}, err
+}
+
+func (r *Reconciler) doHandlePending(actionClient helmclient.ActionInterface, rel *release.Release, log logr.Logger) error {
+	if r.markFailedAfter <= 0 {
+		return errors.New("Release is in a pending (locked) state and cannot be modified. User intervention is required.")
+	}
+	if rel.Info == nil || rel.Info.LastDeployed.IsZero() {
+		return errors.New("Release is in a pending (locked) state and lacks 'last deployed' timestamp. User intervention is required.")
+	}
+	if pendingSince := time.Since(rel.Info.LastDeployed.Time); pendingSince < r.markFailedAfter {
+		return fmt.Errorf("Release is in a pending (locked) state and cannot currently be modified. Release will be marked failed to allow a roll-forward in %v.", r.markFailedAfter-pendingSince)
+	}
+
+	log.Info("Marking release as failed", "releaseName", rel.Name)
+	err := actionClient.MarkFailed(rel, fmt.Sprintf("operator marked pending (locked) release as failed after state did not change for %v", r.markFailedAfter))
+	if err != nil {
+		return fmt.Errorf("Failed to mark pending (locked) release as failed: %w", err)
+	}
+	return fmt.Errorf("marked release %s as failed to allow upgrade to succeed in next reconcile attempt", rel.Name)
 }
 
 func (r *Reconciler) reportOverrideEvents(obj runtime.Object) {

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -81,6 +81,8 @@ type Reconciler struct {
 	markFailedAfter         time.Duration
 	maxHistory              int
 
+	stripManifestFromStatus bool
+
 	annotSetupOnce       sync.Once
 	annotations          map[string]struct{}
 	installAnnotations   map[string]annotation.Install
@@ -261,6 +263,17 @@ func WithOverrideValues(overrides map[string]string) Option {
 func SkipDependentWatches(skip bool) Option {
 	return func(r *Reconciler) error {
 		r.skipDependentWatches = skip
+		return nil
+	}
+}
+
+// StripManifestFromStatus is an Option that configures whether the manifest
+// should be removed from the automatically populated status.
+// This is recommended if the manifest might return sensitive data (i.e.,
+// secrets).
+func StripManifestFromStatus(strip bool) Option {
+	return func(r *Reconciler) error {
+		r.stripManifestFromStatus = strip
 		return nil
 	}
 }
@@ -528,7 +541,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.
 	if errors.Is(err, driver.ErrReleaseNotFound) {
 		u.UpdateStatus(updater.EnsureCondition(conditions.Deployed(corev1.ConditionFalse, "", "")))
 	} else if err == nil {
-		ensureDeployedRelease(&u, rel)
+		r.ensureDeployedRelease(&u, rel)
 	}
 	u.UpdateStatus(updater.EnsureCondition(conditions.Initialized(corev1.ConditionTrue, "", "")))
 
@@ -615,7 +628,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.
 		}
 	}
 
-	ensureDeployedRelease(&u, rel)
+	r.ensureDeployedRelease(&u, rel)
 	u.UpdateStatus(
 		updater.EnsureCondition(conditions.ReleaseFailed(corev1.ConditionFalse, "", "")),
 		updater.EnsureCondition(conditions.Irreconcilable(corev1.ConditionFalse, "", "")),
@@ -943,7 +956,7 @@ func (r *Reconciler) setupWatches(mgr ctrl.Manager, c controller.Controller) err
 	return nil
 }
 
-func ensureDeployedRelease(u *updater.Updater, rel *release.Release) {
+func (r *Reconciler) ensureDeployedRelease(u *updater.Updater, rel *release.Release) {
 	reason := conditions.ReasonInstallSuccessful
 	message := "release was successfully installed"
 	if rel.Version > 1 {
@@ -953,6 +966,13 @@ func ensureDeployedRelease(u *updater.Updater, rel *release.Release) {
 	if rel.Info != nil && len(rel.Info.Notes) > 0 {
 		message = rel.Info.Notes
 	}
+
+	if r.stripManifestFromStatus {
+		relCopy := *rel
+		relCopy.Manifest = ""
+		rel = &relCopy
+	}
+
 	u.Update(updater.EnsureFinalizer(uninstallFinalizer))
 	u.UpdateStatus(
 		updater.EnsureCondition(conditions.Deployed(corev1.ConditionTrue, reason, message)),

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -116,6 +116,10 @@ func (r *Reconciler) setupAnnotationMaps() {
 	r.uninstallAnnotations = make(map[string]annotation.Uninstall)
 }
 
+type SetupOpts struct {
+	DisableSetupScheme bool
+}
+
 // SetupWithManager configures a controller for the Reconciler and registers
 // watches. It also uses the passed Manager to initialize default values for the
 // Reconciler and sets up the manager's scheme with the Reconciler's configured
@@ -123,11 +127,13 @@ func (r *Reconciler) setupAnnotationMaps() {
 //
 // If an error occurs setting up the Reconciler with the manager, it is
 // returned.
-func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, opts SetupOpts) error {
 	controllerName := fmt.Sprintf("%v-controller", strings.ToLower(r.gvk.Kind))
 
 	r.addDefaults(mgr, controllerName)
-	r.setupScheme(mgr)
+	if !opts.DisableSetupScheme {
+		r.setupScheme(mgr)
+	}
 
 	c, err := controller.New(controllerName, mgr, controller.Options{Reconciler: r, MaxConcurrentReconciles: r.maxConcurrentReconciles})
 	if err != nil {

--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -154,6 +154,16 @@ var _ = Describe("Reconciler", func() {
 				Expect(r.skipDependentWatches).To(Equal(true))
 			})
 		})
+		var _ = Describe("StripManifestFromStatus", func() {
+			It("should set to false", func() {
+				Expect(StripManifestFromStatus(false)(r)).To(Succeed())
+				Expect(r.stripManifestFromStatus).To(Equal(false))
+			})
+			It("should set to true", func() {
+				Expect(StripManifestFromStatus(true)(r)).To(Succeed())
+				Expect(r.stripManifestFromStatus).To(Equal(true))
+			})
+		})
 		var _ = Describe("WithMaxConcurrentReconciles", func() {
 			It("should set the reconciler max concurrent reconciled", func() {
 				Expect(WithMaxConcurrentReconciles(1)(r)).To(Succeed())

--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -397,7 +397,7 @@ var _ = Describe("Reconciler", func() {
 				}),
 			)
 			Expect(err).To(BeNil())
-			Expect(r.SetupWithManager(mgr)).To(Succeed())
+			Expect(r.SetupWithManager(mgr, SetupOpts{})).To(Succeed())
 
 			ac, err = r.actionClientGetter.ActionClientFor(obj)
 			Expect(err).To(BeNil())

--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -173,6 +173,19 @@ var _ = Describe("Reconciler", func() {
 				Expect(WithReconcilePeriod(-time.Nanosecond)(r)).NotTo(Succeed())
 			})
 		})
+		var _ = Describe("WithMaxReleaseHistory", func() {
+			It("should set the max history size", func() {
+				Expect(WithMaxReleaseHistory(10)(r)).To(Succeed())
+				Expect(r.maxHistory).To(Equal(10))
+			})
+			It("should allow setting the history to unlimited", func() {
+				Expect(WithMaxReleaseHistory(0)(r)).To(Succeed())
+				Expect(r.maxHistory).To(Equal(0))
+			})
+			It("should fail if value is less than 0", func() {
+				Expect(WithMaxReleaseHistory(-1)(r)).NotTo(Succeed())
+			})
+		})
 		var _ = Describe("WithInstallAnnotations", func() {
 			It("should set multiple reconciler install annotations", func() {
 				a1 := annotation.InstallDisableHooks{CustomName: "my.domain/custom-name1"}

--- a/pkg/values/values.go
+++ b/pkg/values/values.go
@@ -17,6 +17,7 @@ limitations under the License.
 package values
 
 import (
+	"context"
 	"helm.sh/helm/v3/pkg/chartutil"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -34,11 +35,11 @@ func (m MapperFunc) Map(v chartutil.Values) chartutil.Values {
 }
 
 type Translator interface {
-	Translate(unstructured *unstructured.Unstructured) (chartutil.Values, error)
+	Translate(ctx context.Context, unstructured *unstructured.Unstructured) (chartutil.Values, error)
 }
 
-type TranslatorFunc func(*unstructured.Unstructured) (chartutil.Values, error)
+type TranslatorFunc func(context.Context, *unstructured.Unstructured) (chartutil.Values, error)
 
-func (t TranslatorFunc) Translate(u *unstructured.Unstructured) (chartutil.Values, error) {
-	return t(u)
+func (t TranslatorFunc) Translate(ctx context.Context, u *unstructured.Unstructured) (chartutil.Values, error) {
+	return t(ctx, u)
 }

--- a/pkg/values/values.go
+++ b/pkg/values/values.go
@@ -18,7 +18,10 @@ package values
 
 import (
 	"helm.sh/helm/v3/pkg/chartutil"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
+
+// TODO: Consider deprecating Mapper and overrides in favour of Translator.
 
 type Mapper interface {
 	Map(chartutil.Values) chartutil.Values
@@ -28,4 +31,14 @@ type MapperFunc func(chartutil.Values) chartutil.Values
 
 func (m MapperFunc) Map(v chartutil.Values) chartutil.Values {
 	return m(v)
+}
+
+type Translator interface {
+	Translate(unstructured *unstructured.Unstructured) (chartutil.Values, error)
+}
+
+type TranslatorFunc func(*unstructured.Unstructured) (chartutil.Values, error)
+
+func (t TranslatorFunc) Translate(u *unstructured.Unstructured) (chartutil.Values, error) {
+	return t(u)
 }


### PR DESCRIPTION
This PR adds an `WithExtraDependentWatches` option, that allows marking certain resources as watched, even if dependent watches are generally disabled.