### PR TITLE
Fix reconciler log format message

### DIFF
--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -593,7 +593,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.
 	obj.SetGroupVersionKind(*r.gvk)
 	err = r.client.Get(ctx, req.NamespacedName, obj)
 	if apierrors.IsNotFound(err) {
-		log.V(1).Info("Resource %s/%s not found, nothing to do", req.NamespacedName.Namespace, req.NamespacedName.Name)
+		log.V(1).Info(fmt.Sprintf("Resource %s/%s not found, nothing to do", req.NamespacedName.Namespace, req.NamespacedName.Name))
 		return ctrl.Result{}, nil
 	}
 	if err != nil {


### PR DESCRIPTION
Currently the log reads as follows:

```
1.654607389961301e+09   DEBUG   controllers.Helm        Resource %s/%s not found, nothing to do {"central": "test-central-1/test-central-1", "test-central-1": "test-central-1"}
```

There is no `.Infof` method, but the source code suggests that `fmt.Sprintf` is to be used for format interpolation.
