### PR TITLE
ROX-10935: Clone the REST config to prevent data races in the k8s.io/cli-runtime library

### DIFF
--- a/pkg/client/restclientgetter.go
+++ b/pkg/client/restclientgetter.go
@@ -48,7 +48,7 @@ type restClientGetter struct {
 }
 
 func (c *restClientGetter) ToRESTConfig() (*rest.Config, error) {
-	return c.restConfig, nil
+	return rest.CopyConfig(c.restConfig), nil
 }
 
 func (c *restClientGetter) ToDiscoveryClient() (discovery.CachedDiscoveryInterface, error) {


### PR DESCRIPTION
The whole story is described at https://github.com/porridge/config-race-repro