### PR TITLE
Rebase on top of upstream

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,5 @@
+upstream-triage:
+  - "./*"
 area/main-binary:
   - 'main.go'
   - 'internal/**/*'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,7 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - '**'
-  pull_request:
-    branches: [ main ]
+  - push
 
 jobs:
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,13 +1,14 @@
 name: Deploy
 
-on:
-  push:
-    branches:
-      - '**'
-    tags:
-      - 'v*'
-  pull_request:
-    branches: [ main ]
+# Disabled as we don't need docker images to use the helm-operator as a library.
+#on:
+#  push:
+#    branches:
+#      - '**'
+#    tags:
+#      - 'v*'
+#  pull_request:
+#    branches: [ main ]
 
 jobs:
   goreleaser:

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ by mapping the [values](https://helm.sh/docs/chart_template_guide/values_files/)
 
 For creating a [Level II+](https://sdk.operatorframework.io/docs/advanced-topics/operator-capabilities/operator-capabilities/) operator 
 that reuses an already existing Helm chart, we need a [hybrid](https://github.com/operator-framework/operator-sdk/issues/670)
-between the Go and Helm operator types is.
+between the Go and Helm operator types.
 
 The hybrid approach allows adding customizations to the Helm operator, such as:
 - value mapping based on cluster state, or 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # helm-operator
 
-[![Build Status](https://github.com/stackrox/helm-operator/workflows/CI/badge.svg?branch=main)
+![Build Status](https://github.com/stackrox/helm-operator/workflows/CI/badge.svg?branch=main)
 
 Reimplementation of the helm operator to enrich the Helm operator's reconciliation with custom Go code to create a 
 hybrid operator.
@@ -43,41 +43,42 @@ if err := reconciler.SetupWithManager(mgr); err != nil {
 
 ## Why a fork?
 
-Initially the Helm operator type was designed to automate Helm chart operations
+The Helm operator type automates Helm chart operations
 by mapping the [values](https://helm.sh/docs/chart_template_guide/values_files/) of a Helm chart exactly to a 
 `CustomResourceDefinition` and defining its watched resources in a `watches.yaml` 
-[configuration](https://sdk.operatorframework.io/docs/building-operators/helm/tutorial/#watch-the-nginx-cr).
+[configuration](https://sdk.operatorframework.io/docs/building-operators/helm/tutorial/#watch-the-nginx-cr) file.
 
-To write a [Level II+](https://sdk.operatorframework.io/docs/advanced-topics/operator-capabilities/operator-capabilities/) operator 
-which reuses an already existing Helm chart a [hybrid](https://github.com/operator-framework/operator-sdk/issues/670)
-between the Go and Helm operator type is necessary.
+For creating a [Level II+](https://sdk.operatorframework.io/docs/advanced-topics/operator-capabilities/operator-capabilities/) operator 
+that reuses an already existing Helm chart, we need a [hybrid](https://github.com/operator-framework/operator-sdk/issues/670)
+between the Go and Helm operator types is.
 
-The hybrid approach allows to add customizations to the Helm operator like value mapping based on cluster state or
-executing code in on specific events.
+The hybrid approach allows adding customizations to the Helm operator, such as:
+- value mapping based on cluster state, or 
+- executing code in specific events.
 
 ### Quickstart
 
-Add this module as a replace directive to your `go.mod`:
+- Add this module as a replace directive to your `go.mod`:
 
-```
-go mod edit -replace=github.com/joelanford/helm-operator=github.com/stackrox/helm-operator@main
-```
+  ```
+  go mod edit -replace=github.com/joelanford/helm-operator=github.com/stackrox/helm-operator@main
+  ```
 
-Example:
+  For example:
 
-```
-chart, err := loader.Load("path/to/chart")
-if err != nil {
-    panic(err)
-}
+  ```go
+  chart, err := loader.Load("path/to/chart")
+  if err != nil {
+     panic(err)
+  }
 
-reconciler := reconciler.New(
-    reconciler.WithChart(*chart),
-    reconciler.WithGroupVersionKind(gvk),
-)
+  reconciler := reconciler.New(
+     reconciler.WithChart(*chart),
+     reconciler.WithGroupVersionKind(gvk),
+  )
 
-if err := reconciler.SetupWithManager(mgr); err != nil {
-    panic(fmt.Sprintf("unable to create reconciler: %s", err))
-}
-```
+  if err := reconciler.SetupWithManager(mgr); err != nil {
+     panic(fmt.Sprintf("unable to create reconciler: %s", err))
+  }
+  ```
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # helm-operator
 
-![Build Status](https://github.com/operator-framework/helm-operator-plugins/workflows/CI/badge.svg?branch=master)
-[![Coverage Status](https://coveralls.io/repos/github/operator-framework/helm-operator-plugins/badge.svg?branch=master)](https://coveralls.io/github/operator-framework/helm-operator-plugins?branch=master)
+[![Build Status](https://github.com/stackrox/helm-operator/workflows/CI/badge.svg?branch=main)
 
 Reimplementation of the helm operator to enrich the Helm operator's reconciliation with custom Go code to create a 
 hybrid operator.
@@ -41,3 +40,44 @@ if err := reconciler.SetupWithManager(mgr); err != nil {
  panic(fmt.Sprintf("unable to create reconciler: %s", err))
 }
 ```
+
+## Why a fork?
+
+Initially the Helm operator type was designed to automate Helm chart operations
+by mapping the [values](https://helm.sh/docs/chart_template_guide/values_files/) of a Helm chart exactly to a 
+`CustomResourceDefinition` and defining its watched resources in a `watches.yaml` 
+[configuration](https://sdk.operatorframework.io/docs/building-operators/helm/tutorial/#watch-the-nginx-cr).
+
+To write a [Level II+](https://sdk.operatorframework.io/docs/advanced-topics/operator-capabilities/operator-capabilities/) operator 
+which reuses an already existing Helm chart a [hybrid](https://github.com/operator-framework/operator-sdk/issues/670)
+between the Go and Helm operator type is necessary.
+
+The hybrid approach allows to add customizations to the Helm operator like value mapping based on cluster state or
+executing code in on specific events.
+
+### Quickstart
+
+Add this module as a replace directive to your `go.mod`:
+
+```
+go mod edit -replace=github.com/joelanford/helm-operator=github.com/stackrox/helm-operator@main
+```
+
+Example:
+
+```
+chart, err := loader.Load("path/to/chart")
+if err != nil {
+    panic(err)
+}
+
+reconciler := reconciler.New(
+    reconciler.WithChart(*chart),
+    reconciler.WithGroupVersionKind(gvk),
+)
+
+if err := reconciler.SetupWithManager(mgr); err != nil {
+    panic(fmt.Sprintf("unable to create reconciler: %s", err))
+}
+```
+

--- a/pkg/client/actionclient.go
+++ b/pkg/client/actionclient.go
@@ -62,6 +62,7 @@ type ActionInterface interface {
 	Get(name string, opts ...GetOption) (*release.Release, error)
 	Install(name, namespace string, chrt *chart.Chart, vals map[string]interface{}, opts ...InstallOption) (*release.Release, error)
 	Upgrade(name, namespace string, chrt *chart.Chart, vals map[string]interface{}, opts ...UpgradeOption) (*release.Release, error)
+	MarkFailed(release *release.Release, reason string) error
 	Uninstall(name string, opts ...UninstallOption) (*release.UninstallReleaseResponse, error)
 	Reconcile(rel *release.Release) error
 }
@@ -178,6 +179,14 @@ func (c *actionClient) Upgrade(name, namespace string, chrt *chart.Chart, vals m
 		return nil, err
 	}
 	return rel, nil
+}
+
+func (c *actionClient) MarkFailed(rel *release.Release, reason string) error {
+	infoCopy := *rel.Info
+	releaseCopy := *rel
+	releaseCopy.Info = &infoCopy
+	releaseCopy.SetStatus(release.StatusFailed, reason)
+	return c.conf.Releases.Update(&releaseCopy)
 }
 
 func (c *actionClient) Uninstall(name string, opts ...UninstallOption) (*release.UninstallReleaseResponse, error) {

--- a/pkg/extensions/types.go
+++ b/pkg/extensions/types.go
@@ -1,0 +1,12 @@
+package extensions
+
+import (
+	"context"
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// ReconcileExtension is an arbitrary extension that can be implemented to run either before
+// or after the main Helm reconciliation action.
+// An error returned by a ReconcileExtension will cause the Reconcile to fail, unlike a hook error.
+type ReconcileExtension func(context.Context, *unstructured.Unstructured, logr.Logger) error

--- a/pkg/extensions/types.go
+++ b/pkg/extensions/types.go
@@ -2,11 +2,16 @@ package extensions
 
 import (
 	"context"
+
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
+// UpdateStatusFunc is a function that updates an unstructured status. If the status has been modified,
+// true must be returned, false otherwise.
+type UpdateStatusFunc func(*unstructured.Unstructured) bool
+
 // ReconcileExtension is an arbitrary extension that can be implemented to run either before
 // or after the main Helm reconciliation action.
 // An error returned by a ReconcileExtension will cause the Reconcile to fail, unlike a hook error.
-type ReconcileExtension func(context.Context, *unstructured.Unstructured, logr.Logger) error
+type ReconcileExtension func(context.Context, *unstructured.Unstructured, func(UpdateStatusFunc), logr.Logger) error

--- a/pkg/reconciler/internal/conditions/conditions.go
+++ b/pkg/reconciler/internal/conditions/conditions.go
@@ -41,6 +41,7 @@ const (
 	ReasonUpgradeError             = status.ConditionReason("UpgradeError")
 	ReasonReconcileError           = status.ConditionReason("ReconcileError")
 	ReasonUninstallError           = status.ConditionReason("UninstallError")
+	ReasonPendingError             = status.ConditionReason("PendingError")
 )
 
 func Initialized(stat corev1.ConditionStatus, reason status.ConditionReason, message interface{}) status.Condition {

--- a/pkg/reconciler/internal/updater/updater.go
+++ b/pkg/reconciler/internal/updater/updater.go
@@ -26,8 +26,8 @@ import (
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/operator-framework/helm-operator/pkg/extensions"
 	"github.com/operator-framework/helm-operator-plugins/internal/sdk/controllerutil"
+	"github.com/operator-framework/helm-operator-plugins/pkg/extensions"
 	"github.com/operator-framework/helm-operator-plugins/pkg/internal/status"
 )
 

--- a/pkg/reconciler/internal/updater/updater_test.go
+++ b/pkg/reconciler/internal/updater/updater_test.go
@@ -32,7 +32,11 @@ import (
 	"github.com/operator-framework/helm-operator-plugins/pkg/reconciler/internal/conditions"
 )
 
-const testFinalizer = "testFinalizer"
+const (
+	testFinalizer           = "testFinalizer"
+	availableReplicasStatus = int64(3)
+	replicasStatus          = int64(5)
+)
 
 var _ = Describe("Updater", func() {
 	var (
@@ -90,12 +94,12 @@ var _ = Describe("Updater", func() {
 		It("should support a mix of standard and custom status updates", func() {
 			u.UpdateStatus(EnsureCondition(conditions.Deployed(corev1.ConditionTrue, "", "")))
 			u.UpdateStatusCustom(func(uSt *unstructured.Unstructured) bool {
-				Expect(unstructured.SetNestedMap(uSt.Object, map[string]interface{}{"bar": "baz"}, "foo")).To(Succeed())
+				Expect(unstructured.SetNestedField(uSt.Object, replicasStatus, "replicas")).To(Succeed())
 				return true
 			})
 			u.UpdateStatus(EnsureCondition(conditions.Irreconcilable(corev1.ConditionFalse, "", "")))
 			u.UpdateStatusCustom(func(uSt *unstructured.Unstructured) bool {
-				Expect(unstructured.SetNestedField(uSt.Object, "quux", "foo", "qux")).To(Succeed())
+				Expect(unstructured.SetNestedField(uSt.Object, availableReplicasStatus, "availableReplicas")).To(Succeed())
 				return true
 			})
 			u.UpdateStatus(EnsureCondition(conditions.Initialized(corev1.ConditionTrue, "", "")))
@@ -107,20 +111,20 @@ var _ = Describe("Updater", func() {
 			Expect(found).To(BeFalse())
 			Expect(err).To(Not(HaveOccurred()))
 
-			val, found, err := unstructured.NestedString(obj.Object, "status", "foo", "bar")
-			Expect(val).To(Equal("baz"))
+			val, found, err := unstructured.NestedInt64(obj.Object, "status", "replicas")
+			Expect(val).To(Equal(replicasStatus))
 			Expect(found).To(BeTrue())
 			Expect(err).To(Not(HaveOccurred()))
 
-			val, found, err = unstructured.NestedString(obj.Object, "status", "foo", "qux")
-			Expect(val).To(Equal("quux"))
+			val, found, err = unstructured.NestedInt64(obj.Object, "status", "availableReplicas")
+			Expect(val).To(Equal(availableReplicasStatus))
 			Expect(found).To(BeTrue())
 			Expect(err).To(Not(HaveOccurred()))
 		})
 
 		It("should preserve any custom status across multiple apply calls", func() {
 			u.UpdateStatusCustom(func(uSt *unstructured.Unstructured) bool {
-				Expect(unstructured.SetNestedMap(uSt.Object, map[string]interface{}{"bar": "baz"}, "foo")).To(Succeed())
+				Expect(unstructured.SetNestedField(uSt.Object, int64(5), "replicas")).To(Succeed())
 				return true
 			})
 			Expect(u.Apply(context.TODO(), obj)).To(Succeed())
@@ -131,8 +135,8 @@ var _ = Describe("Updater", func() {
 			Expect(found).To(BeFalse())
 			Expect(err).To(Not(HaveOccurred()))
 
-			val, found, err := unstructured.NestedString(obj.Object, "status", "foo", "bar")
-			Expect(val).To(Equal("baz"))
+			val, found, err := unstructured.NestedInt64(obj.Object, "status", "replicas")
+			Expect(val).To(Equal(replicasStatus))
 			Expect(found).To(BeTrue())
 			Expect(err).To(Succeed())
 
@@ -146,8 +150,8 @@ var _ = Describe("Updater", func() {
 			Expect(found).To(BeFalse())
 			Expect(err).To(Not(HaveOccurred()))
 
-			val, found, err = unstructured.NestedString(obj.Object, "status", "foo", "bar")
-			Expect(val).To(Equal("baz"))
+			val, found, err = unstructured.NestedInt64(obj.Object, "status", "replicas")
+			Expect(val).To(Equal(replicasStatus))
 			Expect(found).To(BeTrue())
 			Expect(err).To(Succeed())
 		})

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -82,6 +82,7 @@ type Reconciler struct {
 	skipDependentWatches             bool
 	maxConcurrentReconciles          int
 	reconcilePeriod                  time.Duration
+	markFailedAfter         		 time.Duration
 	maxHistory                       int
 	skipPrimaryGVKSchemeRegistration bool
 
@@ -347,6 +348,18 @@ func WithMaxReleaseHistory(maxHistory int) Option {
 			return errors.New("maximum Helm release history size must not be negative")
 		}
 		r.maxHistory = maxHistory
+		return nil
+	}
+}
+
+// WithMarkFailedAfter specifies the duration after which the reconciler will mark a release in a pending (locked)
+// state as false in order to allow rolling forward.
+func WithMarkFailedAfter(duration time.Duration) Option {
+	return func(r *Reconciler) error {
+		if duration < 0 {
+			return errors.New("auto-rollback after duration must not be negative")
+		}
+		r.markFailedAfter = duration
 		return nil
 	}
 }
@@ -631,6 +644,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.
 		)
 		return ctrl.Result{}, err
 	}
+	if state == statePending {
+		return r.handlePending(actionClient, rel, &u, log)
+	}
+
 	u.UpdateStatus(updater.EnsureCondition(conditions.Irreconcilable(corev1.ConditionFalse, "", "")))
 
 	for _, h := range r.preHooks {
@@ -707,6 +724,7 @@ const (
 	stateNeedsInstall helmReleaseState = "needs install"
 	stateNeedsUpgrade helmReleaseState = "needs upgrade"
 	stateUnchanged    helmReleaseState = "unchanged"
+	statePending      helmReleaseState = "pending"
 	stateError        helmReleaseState = "error"
 )
 
@@ -753,6 +771,10 @@ func (r *Reconciler) getReleaseState(client helmclient.ActionInterface, obj meta
 
 	if errors.Is(err, driver.ErrReleaseNotFound) {
 		return nil, stateNeedsInstall, nil
+	}
+
+	if currentRelease.Info != nil && currentRelease.Info.Status.IsPending() {
+		return currentRelease, statePending, nil
 	}
 
 	var opts []helmclient.UpgradeOption
@@ -847,6 +869,35 @@ func (r *Reconciler) doUpgrade(actionClient helmclient.ActionInterface, u *updat
 		fmt.Println(diff.Generate(curRel.Manifest, rel.Manifest))
 	}
 	return rel, nil
+}
+
+func (r *Reconciler) handlePending(actionClient helmclient.ActionInterface, rel *release.Release, u *updater.Updater, log logr.Logger) (ctrl.Result, error) {
+	err := r.doHandlePending(actionClient, rel, log)
+	if err == nil {
+		err = errors.New("unknown error handling pending release")
+	}
+	u.UpdateStatus(
+		updater.EnsureCondition(conditions.Irreconcilable(corev1.ConditionTrue, conditions.ReasonPendingError, err)))
+	return ctrl.Result{}, err
+}
+
+func (r *Reconciler) doHandlePending(actionClient helmclient.ActionInterface, rel *release.Release, log logr.Logger) error {
+	if r.markFailedAfter <= 0 {
+		return errors.New("Release is in a pending (locked) state and cannot be modified. User intervention is required.")
+	}
+	if rel.Info == nil || rel.Info.LastDeployed.IsZero() {
+		return errors.New("Release is in a pending (locked) state and lacks 'last deployed' timestamp. User intervention is required.")
+	}
+	if pendingSince := time.Since(rel.Info.LastDeployed.Time); pendingSince < r.markFailedAfter {
+		return fmt.Errorf("Release is in a pending (locked) state and cannot currently be modified. Release will be marked failed to allow a roll-forward in %v.", r.markFailedAfter-pendingSince)
+	}
+
+	log.Info("Marking release as failed", "releaseName", rel.Name)
+	err := actionClient.MarkFailed(rel, fmt.Sprintf("operator marked pending (locked) release as failed after state did not change for %v", r.markFailedAfter))
+	if err != nil {
+		return fmt.Errorf("Failed to mark pending (locked) release as failed: %w", err)
+	}
+	return fmt.Errorf("marked release %s as failed to allow upgrade to succeed in next reconcile attempt", rel.Name)
 }
 
 func (r *Reconciler) reportOverrideEvents(obj runtime.Object) {

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -594,7 +594,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.
 	obj.SetGroupVersionKind(*r.gvk)
 	err = r.client.Get(ctx, req.NamespacedName, obj)
 	if apierrors.IsNotFound(err) {
-		log.V(1).Info("Resource %s/%s not found, nothing to do", req.NamespacedName.Namespace, req.NamespacedName.Name)
+		log.V(1).Info(fmt.Sprintf("Resource %s/%s not found, nothing to do", req.NamespacedName.Namespace, req.NamespacedName.Name))
 		return ctrl.Result{}, nil
 	}
 	if err != nil {

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -43,13 +43,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	ctrlpredicate "sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	"github.com/operator-framework/helm-operator-plugins/internal/sdk/controllerutil"
 	"github.com/operator-framework/helm-operator-plugins/pkg/annotation"
 	helmclient "github.com/operator-framework/helm-operator-plugins/pkg/client"
+	"github.com/operator-framework/helm-operator-plugins/pkg/extensions"
 	"github.com/operator-framework/helm-operator-plugins/pkg/hook"
 	"github.com/operator-framework/helm-operator-plugins/pkg/reconciler/internal/conditions"
 	"github.com/operator-framework/helm-operator-plugins/pkg/reconciler/internal/diff"
@@ -57,7 +57,6 @@ import (
 	"github.com/operator-framework/helm-operator-plugins/pkg/reconciler/internal/updater"
 	internalvalues "github.com/operator-framework/helm-operator-plugins/pkg/reconciler/internal/values"
 	"github.com/operator-framework/helm-operator-plugins/pkg/values"
-	"github.com/joelanford/helm-operator/pkg/extensions"
 )
 
 const uninstallFinalizer = "uninstall-helm-release"
@@ -81,10 +80,10 @@ type Reconciler struct {
 	selectorPredicate                predicate.Predicate
 	overrideValues                   map[string]string
 	skipDependentWatches             bool
-	extraWatches            []watchDescription
+	extraWatches                     []watchDescription
 	maxConcurrentReconciles          int
 	reconcilePeriod                  time.Duration
-	markFailedAfter         		 time.Duration
+	markFailedAfter                  time.Duration
 	maxHistory                       int
 	skipPrimaryGVKSchemeRegistration bool
 

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -86,6 +86,8 @@ type Reconciler struct {
 	maxHistory                       int
 	skipPrimaryGVKSchemeRegistration bool
 
+	stripManifestFromStatus bool
+
 	annotSetupOnce       sync.Once
 	annotations          map[string]struct{}
 	installAnnotations   map[string]annotation.Install
@@ -262,6 +264,17 @@ func WithOverrideValues(overrides map[string]string) Option {
 func SkipDependentWatches(skip bool) Option {
 	return func(r *Reconciler) error {
 		r.skipDependentWatches = skip
+		return nil
+	}
+}
+
+// StripManifestFromStatus is an Option that configures whether the manifest
+// should be removed from the automatically populated status.
+// This is recommended if the manifest might return sensitive data (i.e.,
+// secrets).
+func StripManifestFromStatus(strip bool) Option {
+	return func(r *Reconciler) error {
+		r.stripManifestFromStatus = strip
 		return nil
 	}
 }
@@ -606,7 +619,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.
 	if errors.Is(err, driver.ErrReleaseNotFound) {
 		u.UpdateStatus(updater.EnsureCondition(conditions.Deployed(corev1.ConditionFalse, "", "")))
 	} else if err == nil {
-		ensureDeployedRelease(&u, rel)
+		r.ensureDeployedRelease(&u, rel)
 	}
 	u.UpdateStatus(updater.EnsureCondition(conditions.Initialized(corev1.ConditionTrue, "", "")))
 
@@ -693,7 +706,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.
 		}
 	}
 
-	ensureDeployedRelease(&u, rel)
+	r.ensureDeployedRelease(&u, rel)
 	u.UpdateStatus(
 		updater.EnsureCondition(conditions.ReleaseFailed(corev1.ConditionFalse, "", "")),
 		updater.EnsureCondition(conditions.Irreconcilable(corev1.ConditionFalse, "", "")),
@@ -1049,7 +1062,7 @@ func (r *Reconciler) setupWatches(mgr ctrl.Manager, c controller.Controller) err
 	return nil
 }
 
-func ensureDeployedRelease(u *updater.Updater, rel *release.Release) {
+func (r *Reconciler) ensureDeployedRelease(u *updater.Updater, rel *release.Release) {
 	reason := conditions.ReasonInstallSuccessful
 	message := "release was successfully installed"
 	if rel.Version > 1 {
@@ -1059,6 +1072,13 @@ func ensureDeployedRelease(u *updater.Updater, rel *release.Release) {
 	if rel.Info != nil && len(rel.Info.Notes) > 0 {
 		message = rel.Info.Notes
 	}
+
+	if r.stripManifestFromStatus {
+		relCopy := *rel
+		relCopy.Manifest = ""
+		rel = &relCopy
+	}
+
 	u.Update(updater.EnsureFinalizer(uninstallFinalizer))
 	u.UpdateStatus(
 		updater.EnsureCondition(conditions.Deployed(corev1.ConditionTrue, reason, message)),

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -624,7 +624,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.
 	u.UpdateStatus(updater.EnsureCondition(conditions.Initialized(corev1.ConditionTrue, "", "")))
 
 	for _, ext := range r.preExtensions {
-		if err := ext(ctx, obj, r.log); err != nil {
+		if err := ext(ctx, obj, u.UpdateStatusCustom, r.log); err != nil {
 			u.UpdateStatus(
 				updater.EnsureCondition(conditions.Irreconcilable(corev1.ConditionTrue, conditions.ReasonReconcileError, err)),
 				updater.EnsureConditionUnknown(conditions.TypeReleaseFailed),
@@ -697,7 +697,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.
 	}
 
 	for _, ext := range r.postExtensions {
-		if err := ext(ctx, obj, r.log); err != nil {
+		if err := ext(ctx, obj, u.UpdateStatusCustom, r.log); err != nil {
 			u.UpdateStatus(
 				updater.EnsureCondition(conditions.Irreconcilable(corev1.ConditionTrue, conditions.ReasonReconcileError, err)),
 				updater.EnsureConditionUnknown(conditions.TypeReleaseFailed),
@@ -967,7 +967,7 @@ func (r *Reconciler) doUninstall(ctx context.Context, actionClient helmclient.Ac
 	}
 
 	for _, ext := range r.postExtensions {
-		if err := ext(ctx, obj, r.log); err != nil {
+		if err := ext(ctx, obj, u.UpdateStatusCustom, r.log); err != nil {
 			u.UpdateStatus(
 				updater.EnsureCondition(conditions.Irreconcilable(corev1.ConditionTrue, conditions.ReasonReconcileError, err)),
 				updater.EnsureConditionUnknown(conditions.TypeReleaseFailed),

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -56,6 +56,7 @@ import (
 	"github.com/operator-framework/helm-operator-plugins/pkg/reconciler/internal/updater"
 	internalvalues "github.com/operator-framework/helm-operator-plugins/pkg/reconciler/internal/values"
 	"github.com/operator-framework/helm-operator-plugins/pkg/values"
+	"github.com/joelanford/helm-operator/pkg/extensions"
 )
 
 const uninstallFinalizer = "uninstall-helm-release"
@@ -69,6 +70,9 @@ type Reconciler struct {
 	eventRecorder      record.EventRecorder
 	preHooks           []hook.PreHook
 	postHooks          []hook.PostHook
+
+	preExtensions  []extensions.ReconcileExtension
+	postExtensions []extensions.ReconcileExtension
 
 	log                              logr.Logger
 	gvk                              *schema.GroupVersionKind
@@ -420,11 +424,41 @@ func WithPreHook(h hook.PreHook) Option {
 	}
 }
 
+// WithPreExtension is an Option that configures the reconciler to run the given
+// extension before performing any reconciliation steps (including values translation).
+// An error returned from the extension will cause the reconciliation to fail.
+// This should be preferred to WithPreHook in most cases, except for when the logic
+// depends on the translated Helm values.
+// The extension will be invoked with the raw object state; meaning it needs to be careful
+// to check for existence of the deletionTimestamp field.
+func WithPreExtension(e extensions.ReconcileExtension) Option {
+	return func(r *Reconciler) error {
+		r.preExtensions = append(r.preExtensions, e)
+		return nil
+	}
+}
+
 // WithPostHook is an Option that configures the reconciler to run the given
 // PostHook just after performing any non-uninstall release actions.
 func WithPostHook(h hook.PostHook) Option {
 	return func(r *Reconciler) error {
 		r.postHooks = append(r.postHooks, h)
+		return nil
+	}
+}
+
+// WithPostExtension is an Option that configures the reconciler to run the given
+// extension after performing any reconciliation steps (including uninstall of the release,
+// but not removal of the finalizer).
+// An error returned from the extension will cause the reconciliation to fail, which might
+// prevent the finalizer from getting removed.
+// This should be preferred to WithPostHook in most cases, except for when the logic
+// depends on the translated Helm values.
+// The extension will be invoked with the raw object state; meaning it needs to be careful
+// to check for existence of the deletionTimestamp field.
+func WithPostExtension(e extensions.ReconcileExtension) Option {
+	return func(r *Reconciler) error {
+		r.postExtensions = append(r.postExtensions, e)
 		return nil
 	}
 }
@@ -563,6 +597,16 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.
 	}
 	u.UpdateStatus(updater.EnsureCondition(conditions.Initialized(corev1.ConditionTrue, "", "")))
 
+	for _, ext := range r.preExtensions {
+		if err := ext(ctx, obj, r.log); err != nil {
+			u.UpdateStatus(
+				updater.EnsureCondition(conditions.Irreconcilable(corev1.ConditionTrue, conditions.ReasonReconcileError, err)),
+				updater.EnsureConditionUnknown(conditions.TypeReleaseFailed),
+			)
+			return ctrl.Result{}, err
+		}
+	}
+
 	if obj.GetDeletionTimestamp() != nil {
 		err := r.handleDeletion(ctx, actionClient, obj, log)
 		return ctrl.Result{}, err
@@ -622,6 +666,16 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.
 		}
 	}
 
+	for _, ext := range r.postExtensions {
+		if err := ext(ctx, obj, r.log); err != nil {
+			u.UpdateStatus(
+				updater.EnsureCondition(conditions.Irreconcilable(corev1.ConditionTrue, conditions.ReasonReconcileError, err)),
+				updater.EnsureConditionUnknown(conditions.TypeReleaseFailed),
+			)
+			return ctrl.Result{}, err
+		}
+	}
+
 	ensureDeployedRelease(&u, rel)
 	u.UpdateStatus(
 		updater.EnsureCondition(conditions.ReleaseFailed(corev1.ConditionFalse, "", "")),
@@ -676,7 +730,7 @@ func (r *Reconciler) handleDeletion(ctx context.Context, actionClient helmclient
 				err = applyErr
 			}
 		}()
-		return r.doUninstall(actionClient, &uninstallUpdater, obj, log)
+		return r.doUninstall(ctx, actionClient, &uninstallUpdater, obj, log)
 	}(); err != nil {
 		return err
 	}
@@ -822,7 +876,7 @@ func (r *Reconciler) doReconcile(actionClient helmclient.ActionInterface, u *upd
 	return nil
 }
 
-func (r *Reconciler) doUninstall(actionClient helmclient.ActionInterface, u *updater.Updater, obj *unstructured.Unstructured, log logr.Logger) error {
+func (r *Reconciler) doUninstall(ctx context.Context, actionClient helmclient.ActionInterface, u *updater.Updater, obj *unstructured.Unstructured, log logr.Logger) error {
 	var opts []helmclient.UninstallOption
 	for name, annot := range r.uninstallAnnotations {
 		if v, ok := obj.GetAnnotations()[name]; ok {
@@ -847,6 +901,17 @@ func (r *Reconciler) doUninstall(actionClient helmclient.ActionInterface, u *upd
 			fmt.Println(diff.Generate(resp.Release.Manifest, ""))
 		}
 	}
+
+	for _, ext := range r.postExtensions {
+		if err := ext(ctx, obj, r.log); err != nil {
+			u.UpdateStatus(
+				updater.EnsureCondition(conditions.Irreconcilable(corev1.ConditionTrue, conditions.ReasonReconcileError, err)),
+				updater.EnsureConditionUnknown(conditions.TypeReleaseFailed),
+			)
+			return err
+		}
+	}
+
 	u.Update(updater.RemoveFinalizer(uninstallFinalizer))
 	u.UpdateStatus(
 		updater.EnsureCondition(conditions.ReleaseFailed(corev1.ConditionFalse, "", "")),

--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -191,6 +191,16 @@ var _ = Describe("Reconciler", func() {
 				Expect(r.skipDependentWatches).To(Equal(true))
 			})
 		})
+		var _ = Describe("StripManifestFromStatus", func() {
+			It("should set to false", func() {
+				Expect(StripManifestFromStatus(false)(r)).To(Succeed())
+				Expect(r.stripManifestFromStatus).To(Equal(false))
+			})
+			It("should set to true", func() {
+				Expect(StripManifestFromStatus(true)(r)).To(Succeed())
+				Expect(r.stripManifestFromStatus).To(Equal(true))
+			})
+		})
 		var _ = Describe("WithMaxConcurrentReconciles", func() {
 			It("should set the reconciler max concurrent reconciled", func() {
 				Expect(WithMaxConcurrentReconciles(1)(r)).To(Succeed())


### PR DESCRIPTION
- add release manifest diff to more verbose logs (#162)
- add a nil check for Watch Selector field (#164)
- release prep for v0.0.10 (#167)
- update testdata (#168)
- log manager options (#165)
- update kb from 3.3.0 to the latest commit 800fdeec6e5c (#169)
- fix goreleaser fetch script (#173)
- bump dependencies to support k8s 1.24 (#174)
- Update init.go (#175)
- release v0.0.11 prep (#176)
- update testdata (#177)
- patch makefile for envtest 1.24 (#178)
- update kubebuilder to latest commit (#179)
- update scaffolds for hybrid to use go 1.18 (#180)
- (chore): bump Kubebuilder to commit `57aed3f94a441973deff4121a0538e20dda422a8` (#181)
- bump go to 1.18 in scaffolded Dockerfile (#182)
- Add owners file (#184)
- Upgrade project to use kustomize v4.5.5 and bump kubebuilder release 3.6.0 (#187)
- Make a copy of rest.Config provided to k8s.io/cli-runtime. (#190)
- updated v1alpha scaffolding (#191)
- added warning message for deprecated flag (#193)
- Fork helm-operator adjustments for CI and documentation (#4)
- Updated README (#5)
- fixed typo in README (#7)
- Allow adding reconciliation extensions (#9)
- Allow marking releases stuck in a pending state as failed (#16)
- Allow stripping manifest from the CR status (#18)
- ROX-7242: Make the operator preserve custom statuses, and allow updating custom status through extensions (#17)
- ROX- 8130: Add WithExtraWatch option. (#22)
- Fix updater test to use existing fields from deployment's status field
- Fix reconciler log format message (#25)
