### PR TITLE
ROX-17712: Remove updater onConflict retry

### DIFF
--- a/pkg/client/actionclient.go
+++ b/pkg/client/actionclient.go
@@ -268,6 +268,7 @@ func (c *actionClient) rollback(name string, opts ...RollbackOption) error {
 	return rollback.Run(name)
 }
 
+
 func (c *actionClient) Uninstall(name string, opts ...UninstallOption) (*release.UninstallReleaseResponse, error) {
 	return c.uninstall(name, concat(c.defaultUninstallOpts, opts...)...)
 }

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -83,7 +83,7 @@ type Reconciler struct {
 	extraWatches                     []watchDescription
 	maxConcurrentReconciles          int
 	reconcilePeriod                  time.Duration
-	markFailedAfter                  time.Duration
+	markFailedAfter         		 time.Duration
 	maxHistory                       int
 	skipPrimaryGVKSchemeRegistration bool
 

--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -710,9 +710,10 @@ var _ = Describe("Reconciler", func() {
 							})
 
 							By("successfully reconciling a request", func() {
-								res, err := r.Reconcile(ctx, req)
-								Expect(res).To(Equal(reconcile.Result{}))
-								Expect(err).To(BeNil())
+								Eventually(func() error {
+									_, err := r.Reconcile(ctx, req)
+									return err
+								}).Should(Succeed())
 							})
 
 							By("ensuring the finalizer is removed and the CR is deleted", func() {
@@ -1316,9 +1317,10 @@ var _ = Describe("Reconciler", func() {
 								})
 
 								By("successfully reconciling a request", func() {
-									res, err := r.Reconcile(ctx, req)
-									Expect(res).To(Equal(reconcile.Result{}))
-									Expect(err).To(BeNil())
+									Eventually(func() error {
+										_, err := r.Reconcile(ctx, req)
+										return err
+									}).Should(Succeed())
 								})
 
 								By("verifying the release is uninstalled", func() {
@@ -1374,9 +1376,10 @@ var _ = Describe("Reconciler", func() {
 								})
 
 								By("successfully reconciling a request", func() {
-									res, err := r.Reconcile(ctx, req)
-									Expect(res).To(Equal(reconcile.Result{}))
-									Expect(err).To(BeNil())
+									Eventually(func() error {
+										_, err := r.Reconcile(ctx, req)
+										return err
+									}).Should(Succeed())
 								})
 
 								By("verifying the release is uninstalled", func() {

--- a/testdata/hybrid/memcached-operator/api/v1alpha1/groupversion_info.go
+++ b/testdata/hybrid/memcached-operator/api/v1alpha1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1alpha1 contains API Schema definitions for the cache v1alpha1 API group
-// +kubebuilder:object:generate=true
-// +groupName=cache.my.domain
+//+kubebuilder:object:generate=true
+//+groupName=cache.my.domain
 package v1alpha1
 
 import (


### PR DESCRIPTION
The updater has some logic to retry an update in case of a conflict. But AFAIK, this retry would never lead to a successful response whenever there is a conflict in the first place. 

This retry logic doesn't make sense because
- A resource that was changed on the server will never be able to be updated before being refreshed
- It will make the next attempts much more likely to fail, as it delays those attempts with a backoff

This PR removes the retry logic on updates