### PR TITLE
ROX-19221: Fix reconciling with label selector for multiple reconcilers

### DIFF
--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -277,7 +277,7 @@ func WithOverrideValues(overrides map[string]string) Option {
 	}
 }
 
-// WithDependentWatchesEnabled is an Option that configures whether the
+// SkipDependentWatches is an Option that configures whether the
 // Reconciler will register watches for dependent objects in releases and
 // trigger reconciliations when they change.
 //
@@ -598,7 +598,7 @@ func WithControllerSetupFunc(f ControllerSetupFunc) Option {
 }
 
 // ControllerSetup allows restricted access to the Controller using the WithControllerSetupFunc option.
-// Currently the only supposed configuration is adding additional watchers do the controller.
+// Currently, the only supposed configuration is adding additional watchers do the controller.
 type ControllerSetup interface {
 	// Watch takes events provided by a Source and uses the EventHandler to
 	// enqueue reconcile.Requests in response to the events.

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -1161,6 +1161,7 @@ func (r *Reconciler) setupWatches(mgr ctrl.Manager, c controller.Controller) err
 	if err := c.Watch(
 		source.Kind(mgr.GetCache(), secret),
 		handler.EnqueueRequestForOwner(mgr.GetScheme(), mgr.GetRESTMapper(), obj, handler.OnlyControllerOwner()),
+		preds...,
 	); err != nil {
 		return err
 	}

--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -517,6 +517,8 @@ var _ = Describe("Reconciler", func() {
 			cancel()
 		})
 
+		selector := metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}}
+
 		// After migration to Ginkgo v2 this can be rewritten using e.g. DescribeTable.
 		parameterizedReconcilerTests := func(opts reconcilerTestSuiteOpts) {
 			BeforeEach(func() {
@@ -535,6 +537,7 @@ var _ = Describe("Reconciler", func() {
 						WithUpgradeAnnotations(annotation.UpgradeDescription{}),
 						WithUninstallAnnotations(annotation.UninstallDescription{}),
 						WithPauseReconcileAnnotation("my.domain/pause-reconcile"),
+						WithSelector(selector),
 						WithOverrideValues(map[string]string{
 							"image.repository": "custom-nginx",
 						}),
@@ -550,6 +553,7 @@ var _ = Describe("Reconciler", func() {
 						WithUpgradeAnnotations(annotation.UpgradeDescription{}),
 						WithUninstallAnnotations(annotation.UninstallDescription{}),
 						WithPauseReconcileAnnotation("my.domain/pause-reconcile"),
+						WithSelector(selector),
 						WithOverrideValues(map[string]string{
 							"image.repository": "custom-nginx",
 						}),
@@ -1392,6 +1396,21 @@ var _ = Describe("Reconciler", func() {
 								})
 							})
 						})
+						When("label selector is present", func() {
+							It("reconciles only with label", func() {
+								By("adding label to the CR", func() {
+									Expect(mgr.GetClient().Get(ctx, objKey, obj)).To(Succeed())
+									obj.SetLabels(map[string]string{"foo": "bar"})
+									Expect(mgr.GetClient().Update(ctx, obj)).To(Succeed())
+								})
+
+								By("successfully reconciling a request", func() {
+									res, err := r.Reconcile(ctx, req)
+									Expect(res).To(Equal(reconcile.Result{}))
+									Expect(err).To(BeNil())
+								})
+							})
+						})
 					})
 				})
 			})
@@ -1442,6 +1461,67 @@ var _ = Describe("Reconciler", func() {
 		It("Setting up reconciler with manager causes custom builder setup to be executed", func() {
 			Expect(r.SetupWithManager(mgr)).To(Succeed())
 			Expect(controllerSetupCalled).To(BeTrue())
+		})
+	})
+
+	var _ = Describe("Test label selector for two reconcilers", func() {
+		var (
+			mgr              manager.Manager
+			firstReconciler  *Reconciler
+			secondReconciler *Reconciler
+			err              error
+		)
+		ctx := context.Background()
+		obj := testutil.BuildTestCR(gvk)
+		objKey := types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()}
+		req := reconcile.Request{NamespacedName: objKey}
+
+		It("Building two reconcilers", func() {
+			By("preparing first reconciler", func() {
+				mgr = getManagerOrFail()
+				firstReconciler, err = New(
+					WithGroupVersionKind(gvk),
+					WithChart(chrt),
+					WithInstallAnnotations(annotation.InstallDescription{}),
+					WithUpgradeAnnotations(annotation.UpgradeDescription{}),
+					WithUninstallAnnotations(annotation.UninstallDescription{}),
+					WithOverrideValues(map[string]string{
+						"image.repository": "custom-nginx",
+					}),
+					WithSelector(metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}}),
+				)
+				Expect(err).To(BeNil())
+				Expect(firstReconciler.SetupWithManager(mgr)).To(Succeed())
+			})
+
+			By("preparing first reconciler", func() {
+				secondReconciler, err = New(
+					WithGroupVersionKind(gvk),
+					WithChart(chrt),
+					WithInstallAnnotations(annotation.InstallDescription{}),
+					WithUpgradeAnnotations(annotation.UpgradeDescription{}),
+					WithUninstallAnnotations(annotation.UninstallDescription{}),
+					WithOverrideValues(map[string]string{
+						"image.repository": "custom-nginx",
+					}),
+					WithSelector(metav1.LabelSelector{MatchLabels: map[string]string{"foo": "baz"}}),
+				)
+				Expect(err).To(BeNil())
+				Expect(secondReconciler.SetupWithManager(mgr)).To(Succeed())
+			})
+		})
+
+		It("Successfully reconcile", func() {
+			obj.SetLabels(map[string]string{"foo": "bar"})
+			Expect(mgr.GetClient().Create(ctx, obj)).To(Succeed())
+
+			res, err := firstReconciler.Reconcile(ctx, req)
+			Expect(res).To(Equal(reconcile.Result{}))
+			Expect(err).To(BeNil())
+
+			res, err = secondReconciler.Reconcile(ctx, req)
+			Expect(res).To(Equal(reconcile.Result{}))
+			Expect(err).To(BeNil())
 		})
 	})
 })

--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -1399,7 +1399,7 @@ var _ = Describe("Reconciler", func() {
 						})
 						When("label selector succeeds", func() {
 							It("reconciles only matching label", func() {
-								By("setting a broken action client getter for the reconciler", func() {
+								By("setting an invalid action client getter to assert different reconcile results", func() {
 									r.actionClientGetter = helmclient.ActionClientGetterFunc(func(client.Object) (helmclient.ActionInterface, error) {
 										fakeClient := helmfake.NewActionClient()
 										return &fakeClient, nil


### PR DESCRIPTION
### Issue
Assume there is CR with label `foo=bar`. 
If run one reconciler with label selector `foo=bar` then everything is fine and the reconciler processes the CR.
If start another reconciler with label `foo=another` then this new reconciler also reconciles `foo=bar` CR. This is not expected.

### Root cause
There is [controller.Watch](https://github.com/stackrox/helm-operator/blob/main/pkg/reconciler/reconciler.go#L1161-L1164) set for `Secret` kind. This watch has event handler. The Event handler only filters events by `GroupVersionKind` of the CR so label selector is ignored

### Fix
Check for the matching label selector before performing reconcile. Skip reconcile if label is not matching

### Local testing with stackrox operator on fresh cluster
```
# Create namespace for the Central
k create ns stackrox

# Create simple Central CR
k apply -f ~/example-central.yml

# Set foo=bar label 
k label centrals.platform.stackrox.io stackrox-central-services foo=bar -n stackrox

# Run operator
CENTRAL_LABEL_SELECTOR="foo=bar" MAIN_IMAGE_TAG=4.1.1 make install run
...
2023-08-22T02:02:15+02:00	INFO	controller-runtime.metrics	Metrics server is starting to listen	{"addr": ":8080"}
2023-08-22T02:02:15+02:00	INFO	setup	skipping webhook setup, ENABLE_WEBHOOKS==false
2023-08-22T02:02:15+02:00	INFO	setup	using Central label selector from environment variable CENTRAL_LABEL_SELECTOR	{"selector": "foo=bar"}
2023-08-22T02:02:15+02:00	INFO	Using central label selector	{"selector": "foo=bar"}
....
2023-08-22T02:02:15+02:00	INFO	setup	starting manager
2023-08-22T02:02:15+02:00	INFO	starting server	{"path": "/metrics", "kind": "metrics", "addr": "[::]:8080"}
2023-08-22T02:02:15+02:00	INFO	Starting server	{"kind": "health probe", "addr": "[::]:8081"}
2023-08-22T02:02:15+02:00	INFO	Starting EventSource	{"controller": "securedcluster-controller", "source": "kind source: *unstructured.Unstructured"}
2023-08-22T02:02:15+02:00	INFO	Starting EventSource	{"controller": "securedcluster-controller", "source": "kind source: *v1.Secret"}
2023-08-22T02:02:15+02:00	INFO	Starting EventSource	{"controller": "securedcluster-controller", "source": "kind source: *v1alpha1.Central"}
2023-08-22T02:02:15+02:00	INFO	Starting Controller	{"controller": "securedcluster-controller"}
2023-08-22T02:02:15+02:00	INFO	Starting EventSource	{"controller": "central-controller", "source": "kind source: *unstructured.Unstructured"}
2023-08-22T02:02:15+02:00	INFO	Starting EventSource	{"controller": "central-controller", "source": "kind source: *v1.Secret"}
2023-08-22T02:02:15+02:00	INFO	Starting EventSource	{"controller": "central-controller", "source": "kind source: *v1alpha1.SecuredCluster"}
....
# Check that reoncile is triggered
2023-08-22T02:24:20+02:00	DEBUG	controllers.Central	Reconciliation triggered	{"central": {"name":"stackrox-central-services","namespace":"stackrox"}}
2023-08-22T02:24:20+02:00	DEBUG	controllers.Central	Adding uninstall finalizer.	{"central": {"name":"stackrox-central-services","namespace":"stackrox"}}
2023-08-22T02:24:22+02:00	DEBUG	Get release 'stackrox-central-services' latest version.
2023-08-22T02:24:22+02:00	DEBUG	controllers.Central	release not found, most likely it is not installed yet	{"namespace": "stackrox", "name": "stackrox-central-services"}


# Start another operator instance with different label selector
...
CENTRAL_LABEL_SELECTOR="foo=another" MAIN_IMAGE_TAG=4.1.1 make install run
2023-08-22T04:28:29+02:00	INFO	controller-runtime.metrics	Metrics server is starting to listen	{"addr": ":8090"}
2023-08-22T04:28:29+02:00	INFO	setup	skipping webhook setup, ENABLE_WEBHOOKS==false
2023-08-22T04:28:29+02:00	INFO	setup	using Central label selector from environment variable CENTRAL_LABEL_SELECTOR	{"selector": "foo=another"}
2023-08-22T04:28:29+02:00	INFO	Using central label selector	{"selector": "foo=another"}
...
# Check that another operator does not reconcile foo=bar CR
...

# Change label to foo=another to swap which operator should reconcile the CR
k label centrals.platform.stackrox.io stackrox-central-services foo=another -n stackrox --overwrite=true

# Check that foo=bar operator does not reconcile CR anymore
....

# Check that foo=another operator reconciles the CR
2023-08-22T04:28:29+02:00	DEBUG	controllers.Central	Reconciliation triggered	{"central": {"name":"stackrox-central-services","namespace":"stackrox"}}
2023-08-22T04:28:30+02:00	DEBUG	Get release 'stackrox-central-services' latest version.
2023-08-22T04:28:30+02:00	DEBUG	controllers.Central	release not found, most likely it is not installed yet	{"namespace": "stackrox", "name": "stackrox-central-services"}
...
...

*Note:* provided unit testing does not covers bug behaviour. I have an idea how to test the bug case with custom controller manager cache  but I maybe I am overlooking more simpler approach