### PR TITLE
Do not ever update the status in case the generation has changed

### DIFF
--- a/pkg/reconciler/internal/updater/updater_test.go
+++ b/pkg/reconciler/internal/updater/updater_test.go
@@ -237,6 +237,9 @@ var _ = Describe("Updater", func() {
 		})
 		Context("when in-cluster object has been updated", func() {
 			JustBeforeEach(func() {
+				// Refresh obj first with what is on the cluster, otherwise the following Apply() calls will fail due to
+				// subtle changes in obj's spec and its refreshed counterpart, both of which are empty, but not in the same way...
+				Expect(cl.Get(context.TODO(), types.NamespacedName{Namespace: "testNamespace", Name: "testDeployment"}, obj)).To(Succeed())
 				// Add external status condition on cluster.
 				clusterObj := obj.DeepCopy()
 				unknownCondition := map[string]interface{}{


### PR DESCRIPTION
Noticed this, because the status of RHACS operator includes an "observedGeneration".
The helm-operator prior this change would happily refresh the object and a status updater function registered by the RHACS operator would then happily copy over the `metadata.generation` to the `status.observedGeneration` field. This can happen, if, for example, the user fiddles around with the CR spec while the helm-operator does its reconciliation. In the end we would end up with an inconsistency: updated `observedGeneration` even though that is not the generation corresponding to the `spec` which was reconciled.